### PR TITLE
withShadow util

### DIFF
--- a/packages/stories/src/utils/utils.stories.tsx
+++ b/packages/stories/src/utils/utils.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import styled from 'styled-components';
+// import { action } from '@storybook/addon-actions';
+// import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
+
+import { Grid, Col, withShadow } from 'uikit';
+
+const Block = styled<any>(Col)`
+  height: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  ${withShadow};
+`;
+
+storiesOf('04 / Utils|withShadow', module).add('withShadow', () => (
+  <Grid gap="50px">
+    {[1, 2, 3, 4, 5].map(d => (
+      <Block sm={4} md={2} depth={d}>
+        depth = {d}
+      </Block>
+    ))}
+  </Grid>
+));

--- a/packages/stories/src/utils/utils.stories.tsx
+++ b/packages/stories/src/utils/utils.stories.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import styled from 'styled-components';
-// import { action } from '@storybook/addon-actions';
-// import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
 
 import { Grid, Col, withShadow } from 'uikit';
 

--- a/packages/uikit/src/index.tsx
+++ b/packages/uikit/src/index.tsx
@@ -9,5 +9,7 @@ export { default as Icon } from './atoms/Icon';
 export { default as Icons } from './atoms/Icon/registry';
 export { default as Spacer } from './atoms/Spacer';
 
+export * from './util';
+
 export { default as theme } from './theme';
 export { default as GlobalStyle } from './theme/global';

--- a/packages/uikit/src/util/index.ts
+++ b/packages/uikit/src/util/index.ts
@@ -1,1 +1,2 @@
 export { default as withSpacing } from './withSpacing';
+export { default as withShadow } from './withShadow';

--- a/packages/uikit/src/util/withShadow.test.tsx
+++ b/packages/uikit/src/util/withShadow.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+import withShadow from './withShadow';
+import { mount } from 'enzyme';
+
+describe('Util: withShadow', () => {
+  const Shadow = styled.div<any>`
+    ${withShadow};
+  `;
+
+  it('adds shadow with depth 1', () => {
+    expect(mount(<Shadow depth={1} />)).toHaveStyleRule(
+      'box-shadow',
+      '0 1px 3px 0 rgba(0,0,0,0.1)'
+    );
+  });
+
+  it('adds shadow with depth 2', () => {
+    expect(mount(<Shadow depth={2} />)).toHaveStyleRule(
+      'box-shadow',
+      '0 3px 6px 0 rgba(0,0,0,0.16), 0 3px 6px 0 rgba(0,0,0,0.23)'
+    );
+  });
+
+  it('adds shadow with depth 3', () => {
+    expect(mount(<Shadow depth={3} />)).toHaveStyleRule(
+      'box-shadow',
+      '0 10px 20px 0 rgba(0,0,0,0.19)'
+    );
+  });
+
+  it('adds shadow with depth 4', () => {
+    expect(mount(<Shadow depth={4} />)).toHaveStyleRule(
+      'box-shadow',
+      '0 14px 28px 0 rgba(0,0,0,0.25)'
+    );
+  });
+
+  it('adds shadow with depth 5', () => {
+    expect(mount(<Shadow depth={5} />)).toHaveStyleRule(
+      'box-shadow',
+      '0 19px 38px 0 rgba(0,0,0,0.3), 0 15px 12px 0 rgba(0,0,0,0.22)'
+    );
+  });
+});

--- a/packages/uikit/src/util/withShadow.ts
+++ b/packages/uikit/src/util/withShadow.ts
@@ -1,0 +1,34 @@
+import { css } from '../lib/styledComponents';
+
+interface ShadowProps {
+  depth: 1 | 2 | 3 | 4 | 5;
+}
+
+export default ({ depth }: ShadowProps) => css`
+  ${depth <= 1 &&
+    css`
+      box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+    `}
+
+  ${depth === 2 &&
+    css`
+      box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16),
+        0 3px 6px 0 rgba(0, 0, 0, 0.23);
+    `}
+
+  ${depth === 3 &&
+    css`
+      box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.19);
+    `}
+
+  ${depth === 4 &&
+    css`
+      box-shadow: 0 14px 28px 0 rgba(0, 0, 0, 0.25);
+    `}
+
+  ${depth >= 5 &&
+    css`
+      box-shadow: 0 19px 38px 0 rgba(0, 0, 0, 0.3),
+        0 15px 12px 0 rgba(0, 0, 0, 0.22);
+    `}
+`;


### PR DESCRIPTION
New `withShadow` util that can be used to add shadows to other components.

## Basic Usage

```js
const IWantShadow = styled.div`
  width: 100px;
  height: 100px;

  // if you want the developer to be able to pass in a custom shadow depth
  ${widthShadow};

  // if you want a fixed shadow depth
  ${widthShadow(2)};
`
```

Shadow depth can be `1, 2, 3, 4, 5`