### PR TITLE
CI modification: Storybook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,19 @@ jobs:
         key: npm-packages-{{ checksum "package.json" }}
     - run: yarn lint
     - run: yarn test
+  publish-storybook:
+    executor: shared-setup-exec
+    steps:
+      - checkout
+      - run:
+          name: Install lerna globally
+          command: yarn global add lerna
+      - run:
+          name: Install TypeScript globally
+          command: yarn global add typescript
+      - run:
+          name: Run storybook deploy script
+          command: ~/repo/bin/deploy-gh-pages.sh
   deploy:
     executor: shared-setup-exec
     steps:
@@ -40,12 +53,6 @@ jobs:
         name: Install deps
         command: yarn run bootstrap
     - run:
-        name: Install TypeScript globally
-        command: yarn global add typescript
-    - run:
-        name: Run storybook deploy script
-        command: ~/repo/bin/deploy-gh-pages.sh
-    - run:
         name: Chmod
         command: chmod +x ~/repo/bin/publish-on-npm.sh
     - run:
@@ -56,6 +63,12 @@ workflows:
   build-deploy:
     jobs:
       - build:
+          filters:
+            branches:
+              ignore: gh-pages
+      - publish-storybook:
+          requires:
+            - build
           filters:
             branches:
               ignore: gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
           name: Install lerna globally
           command: yarn global add lerna
       - run:
+          name: Install deps
+          command: yarn run bootstrap
+      - run:
           name: Install TypeScript globally
           command: yarn global add typescript
       - run:

--- a/bin/deploy-gh-pages.sh
+++ b/bin/deploy-gh-pages.sh
@@ -74,12 +74,13 @@ EOF
   curl \
     -H'Content-Type: application/json' \
     -H"Authorization: token $GH_TOKEN" \
-    --data "{\"body\":\"# Storybook deployed ⭐️\\nLink:\\n$DEPLOY_URL\"}" \
+    --data "{\"body\":\"# GitHub Pages Deployment\\nPull Request:\\n$STORYBOOK_PR_URL\\nBranch:\\n$BRANCH_URL\\nStorybook:\\n$DEPLOY_URL\\nBuild:\\n${DEPLOY_URL}dist.zip\"}" \
     https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${STORYBOOK_PR_NUMBER}/comments
 fi
 
 echo "Current working dir:"
 echo $PWD
+
 
 cd ~/repo
 

--- a/bin/deploy-gh-pages.sh
+++ b/bin/deploy-gh-pages.sh
@@ -74,7 +74,7 @@ EOF
   curl \
     -H'Content-Type: application/json' \
     -H"Authorization: token $GH_TOKEN" \
-    --data "{\"body\":\"# Storybook deployed ⭐️\\nLink:\\n$DEPLOY_URL\\"}" \
+    --data "{\"body\":\"# Storybook deployed ⭐️\\nLink:\\n$DEPLOY_URL\"}" \
     https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${STORYBOOK_PR_NUMBER}/comments
 fi
 

--- a/bin/deploy-gh-pages.sh
+++ b/bin/deploy-gh-pages.sh
@@ -74,13 +74,12 @@ EOF
   curl \
     -H'Content-Type: application/json' \
     -H"Authorization: token $GH_TOKEN" \
-    --data "{\"body\":\"# GitHub Pages Deployment\\nPull Request:\\n$STORYBOOK_PR_URL\\nBranch:\\n$BRANCH_URL\\nStorybook:\\n$DEPLOY_URL\\nBuild:\\n${DEPLOY_URL}dist.zip\"}" \
+    --data "{\"body\":\"# Storybook deployed ⭐️\\nLink:\\n$DEPLOY_URL\\"}" \
     https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${STORYBOOK_PR_NUMBER}/comments
 fi
 
 echo "Current working dir:"
 echo $PWD
-
 
 cd ~/repo
 


### PR DESCRIPTION
Move storybook publish to separate CI job so that it can be used on all branches. Currently publishing storybook to github pages only happens as part of the general deploy job for the master branch