### PR TITLE
Fix useEffect lifecycle methods

### DIFF
--- a/packages/uikit/package.json
+++ b/packages/uikit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "The official sofar sounds uikit",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/uikit/src/hooks/useKeyDown.tsx
+++ b/packages/uikit/src/hooks/useKeyDown.tsx
@@ -13,7 +13,7 @@ const useKeyDown = (key: string, callback: () => void) => {
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  });
+  }, []);
 };
 
 export default useKeyDown;

--- a/packages/uikit/src/hooks/useOutsideClick.tsx
+++ b/packages/uikit/src/hooks/useOutsideClick.tsx
@@ -13,7 +13,7 @@ const useOutsideClick = (ref: React.RefObject<any>, callback: () => void) => {
     return () => {
       document.removeEventListener('click', handleClick);
     };
-  });
+  }, []);
 };
 
 export default useOutsideClick;


### PR DESCRIPTION
Fix infinite loop whilst using `useEffect` by including `[]` at the end of the function to prevent react lifecycle