### PR TITLE
Select, Dropdown Fixes

### DIFF
--- a/src/molecules/Dropdown/Dropdown.test.tsx
+++ b/src/molecules/Dropdown/Dropdown.test.tsx
@@ -7,11 +7,13 @@ import Flyout from './Flyout';
 
 const OutsideDiv = () => <button>bla</button>;
 
-const setup = () =>
+const setup = (flyoutContainer: boolean = true) =>
   mountWithTheme(
     <>
       <OutsideDiv />
-      <Dropdown label="I am a dropdown">Dropdown Content</Dropdown>
+      <Dropdown flyoutContainer={flyoutContainer} label="I am a dropdown">
+        Dropdown Content
+      </Dropdown>
     </>
   );
 
@@ -44,6 +46,19 @@ describe('<Dropdown />', () => {
     wrapper.find(Trigger).simulate('click');
     wrapper.find(Trigger).simulate('click');
     expect(wrapper.find(Flyout)).toHaveLength(0);
+  });
+
+  it('render the flyout container with the correct styles', () => {
+    const wrapper = setup(true);
+    wrapper.find(Trigger).simulate('click');
+    expect(wrapper.find(Flyout)).toHaveStyleRule('width', '200px');
+  });
+
+  it('does not render the styled flyout container when the prop is false', () => {
+    const wrapper = setup(false);
+    wrapper.find(Trigger).simulate('click');
+    expect(wrapper.find(Flyout)).toHaveLength(1);
+    expect(wrapper.find(Flyout)).not.toHaveStyleRule('width', '200px');
   });
 
   it.todo('closes the flyout when clicked outside');

--- a/src/molecules/Dropdown/Flyout.test.tsx
+++ b/src/molecules/Dropdown/Flyout.test.tsx
@@ -33,4 +33,11 @@ describe('Dropdown <Flyout />', () => {
       width: '250px'
     });
   });
+
+  it('does not display the styled flyout container when set to false ', () => {
+    const flyout = mountWithTheme(<Flyout flyoutContainer={false} />);
+    expect(flyout).not.toHaveStyleRule('width', '200px');
+    expect(flyout).not.toHaveStyleRule('border-radius', '8px');
+    expect(flyout).not.toHaveStyleRule('overflow-y', 'auto');
+  });
 });

--- a/src/molecules/Dropdown/Flyout.tsx
+++ b/src/molecules/Dropdown/Flyout.tsx
@@ -6,30 +6,33 @@ export type FlyoutSizes = 'small' | 'large';
 
 interface FlyoutProps {
   size?: FlyoutSizes;
+  flyoutContainer?: boolean;
 }
 
 export default styled.div<FlyoutProps>`
-  ${withShadow({ depth: 4 })};
-
-  ${({ theme, size = 'regular' }) => css`
-    background-color: ${theme.colours.whiteDenim};
-    max-height: 300px;
-    margin-top: ${theme.ruler[1]}px;
-    border-radius: ${theme.borderRadius.large};
-    padding: ${theme.ruler[8]}px ${theme.ruler[6]}px;
-
-    overflow-y: auto;
-
-    width: 200px;
-
-    ${size === 'small' &&
+  ${({ theme, size = 'regular', flyoutContainer = true }) => css`
+    ${flyoutContainer &&
       css`
-        width: 150px;
-      `}
+        background-color: ${theme.colours.whiteDenim};
+        ${withShadow({ depth: 4 })};
+        max-height: 300px;
+        margin-top: ${theme.ruler[1]}px;
+        border-radius: ${theme.borderRadius.large};
+        padding: ${theme.ruler[8]}px ${theme.ruler[6]}px;
 
-    ${size === 'large' &&
-      css`
-        width: 250px;
+        overflow-y: auto;
+
+        width: 200px;
+
+        ${size === 'small' &&
+          css`
+            width: 150px;
+          `}
+
+        ${size === 'large' &&
+          css`
+            width: 250px;
+          `}
       `}
   `}
 `;

--- a/src/molecules/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/molecules/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -159,6 +159,7 @@ exports[`<Dropdown /> renders correctly 1`] = `
     </button>
   </OutsideDiv>
   <Dropdown
+    flyoutContainer={true}
     label="I am a dropdown"
   >
     <styled.button

--- a/src/molecules/Dropdown/index.tsx
+++ b/src/molecules/Dropdown/index.tsx
@@ -8,15 +8,17 @@ import Flyout, { FlyoutSizes } from './Flyout';
 
 interface DropdownProps {
   label?: string;
-  renderLabel?: () => any;
+  renderLabel?: (arg?: any) => any;
   children: any;
   size?: FlyoutSizes;
+  flyoutContainer?: boolean;
   'data-qaid'?: string;
 }
 const Dropdown: React.SFC<DropdownProps> = ({
   label,
   renderLabel,
   children,
+  flyoutContainer,
   size,
   'data-qaid': qaId
 }) => {
@@ -30,13 +32,17 @@ const Dropdown: React.SFC<DropdownProps> = ({
   return (
     <>
       <Trigger ref={ref} onClick={() => setIsOpen(!isOpen)} data-qaid={qaId}>
-        {renderLabel ? renderLabel() : label}
+        {renderLabel ? renderLabel(isOpen) : label}
       </Trigger>
 
       {isOpen && (
         <PortalComponent dom={document.body}>
           <StickyContainer stickToEl={ref.current}>
-            <Flyout size={size} data-qaid={`${qaId}-flyout`}>
+            <Flyout
+              flyoutContainer={flyoutContainer}
+              size={size}
+              data-qaid={`${qaId}-flyout`}
+            >
               {children}
             </Flyout>
           </StickyContainer>

--- a/src/molecules/Select/Input.test.tsx
+++ b/src/molecules/Select/Input.test.tsx
@@ -7,10 +7,16 @@ const mockClick = jest.fn();
 
 const setup = (
   isOpen: boolean = false,
-  placeholder: string = 'I am a placeholder'
+  placeholder: string = 'I am a placeholder',
+  readonly: boolean = false
 ) =>
   mountWithTheme(
-    <Input isOpen={isOpen} placeholder={placeholder} toggleSelect={mockClick}>
+    <Input
+      isOpen={isOpen}
+      placeholder={placeholder}
+      toggleSelect={mockClick}
+      readonly={readonly}
+    >
       I am a child component
     </Input>
   );
@@ -60,6 +66,12 @@ describe('Select <Input />', () => {
     let wrapper = setup(true);
     let icon = wrapper.find('Icon').props().name;
     expect(icon).toBe('caretUp');
+  });
+
+  it('adds a readonly prop', () => {
+    let wrapper = setup(true, 'cat', true);
+    let input = wrapper.find('input');
+    expect(input.props().readOnly).toBe(true);
   });
 
   it('it shows the down icon when isOpen is false', () => {

--- a/src/molecules/Select/Input.tsx
+++ b/src/molecules/Select/Input.tsx
@@ -13,7 +13,7 @@ interface SelectInputProps {
 
 interface InputWrapper {
   children?: any;
-  isOpen?: boolean;
+  isOpen?: any;
 }
 
 interface Props {
@@ -60,7 +60,7 @@ const InputWrapper = styled.div<InputWrapper>`
 `;
 
 const InputStyle = styled.input<InputProps & SelectInputProps>`
-  ${({ theme, readonly }) => css`
+  ${({ theme, readOnly }) => css`
     border-right: 0px;
     width: 100%;
     border: 0px;
@@ -80,7 +80,7 @@ const InputStyle = styled.input<InputProps & SelectInputProps>`
       color: ${theme.colours.blueSmoke};
     }
 
-    ${readonly &&
+    ${readOnly &&
       css`
         cursor: pointer;
       `}

--- a/src/molecules/Select/Input.tsx
+++ b/src/molecules/Select/Input.tsx
@@ -13,7 +13,7 @@ interface SelectInputProps {
 
 interface InputWrapper {
   children?: any;
-  isOpen?: any;
+  isOpen?: boolean;
 }
 
 interface Props {

--- a/src/molecules/Select/__snapshots__/Input.test.tsx.snap
+++ b/src/molecules/Select/__snapshots__/Input.test.tsx.snap
@@ -430,6 +430,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
   <Input
     isOpen={false}
     placeholder="I am a placeholder"
+    readonly={false}
     toggleSelect={[MockFunction]}
   >
     <styled.div
@@ -474,6 +475,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
           <styled.input
             isOpen={false}
             placeholder="I am a placeholder"
+            readOnly={false}
           >
             <StyledComponent
               forwardedComponent={
@@ -505,10 +507,12 @@ exports[`Select <Input /> it renders correctly 1`] = `
               forwardedRef={null}
               isOpen={false}
               placeholder="I am a placeholder"
+              readOnly={false}
             >
               <input
                 className="c1"
                 placeholder="I am a placeholder"
+                readOnly={false}
               />
             </StyledComponent>
           </styled.input>

--- a/storybook/stories/Dropdown.stories.tsx
+++ b/storybook/stories/Dropdown.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
 
-import { Icon, Dropdown } from '../../src';
+import { Icon, Dropdown, Select, PrimaryButton } from '../../src';
 
 storiesOf('Dropdown', module)
   .addDecorator(withKnobs)
@@ -11,7 +11,7 @@ storiesOf('Dropdown', module)
     <>
       <h1>Dropdown</h1>
 
-      <Dropdown label="My Dropdown">
+      <Dropdown label="I am a clickable label">
         <b>A Dropdown</b>
         <p>
           A dropdown component can be used to display help information or a
@@ -23,17 +23,12 @@ storiesOf('Dropdown', module)
       <br />
 
       <Dropdown
-        renderLabel={() => (
-          <b>
-            Custom Trigger <Icon name="helpCircleOutline" />
-          </b>
+        flyoutContainer={false}
+        renderLabel={isOpen => (
+          <PrimaryButton>{isOpen ? 'Open' : 'Close'}</PrimaryButton>
         )}
       >
-        <b>Custom Trigger</b>
-        <p>
-          This dropdown uses the renderLabel prop on the dropdown to customise
-          the appearance of the trigger used to open/close the dropdown
-        </p>
+        <Select placeholder="cat" />
       </Dropdown>
     </>
   ));


### PR DESCRIPTION
- Select component didn't correctly pass-through readonly prop to input component with the correct HTML attribute
- Added the ability to hide the styling properties on the dropdown `flyout` container, so that it can become more general-purpose. Allowing you to pass the component into the dropdown without it automatically being wrapped.