### PR TITLE
Fix body-scroll lock issue when autoclosing mobile navbar

### DIFF
--- a/src/molecules/Navbar/index.tsx
+++ b/src/molecules/Navbar/index.tsx
@@ -44,7 +44,7 @@ class Navbar extends React.Component<NavbarProps, NavbarState> {
 
   componentDidUpdate = (_: NavbarProps, prevState: NavbarState) => {
     if (prevState.isMobile && !this.state.isMobile) {
-      this.setState({ open: false });
+      this.onToggle();
     }
   };
 


### PR DESCRIPTION
Simply re-using the existing function which re-enables the body scroll