### PR TITLE
New Sticky Container

### DIFF
--- a/src/atoms/Textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/src/atoms/Textarea/__snapshots__/Textarea.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`<Textarea /> renders correctly 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -204,7 +204,7 @@ exports[`<Textarea /> renders correctly 1`] = `
           "displayName": "styled.textarea",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "textarea",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -411,7 +411,7 @@ exports[`<Textarea /> renders correctly in disabled state 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -429,7 +429,7 @@ exports[`<Textarea /> renders correctly in disabled state 1`] = `
           "displayName": "styled.textarea",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "textarea",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -638,7 +638,7 @@ exports[`<Textarea /> renders correctly in error state 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -656,7 +656,7 @@ exports[`<Textarea /> renders correctly in error state 1`] = `
           "displayName": "styled.textarea",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "textarea",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -864,7 +864,7 @@ exports[`<Textarea /> renders correctly with a value 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -882,7 +882,7 @@ exports[`<Textarea /> renders correctly with a value 1`] = `
           "displayName": "styled.textarea",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "textarea",
           "toString": [Function],
           "warnTooManyClasses": [Function],

--- a/src/atoms/Textfield/__snapshots__/Textfield.test.tsx.snap
+++ b/src/atoms/Textfield/__snapshots__/Textfield.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`<Textfield /> renders correctly 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -196,7 +196,7 @@ exports[`<Textfield /> renders correctly 1`] = `
           "displayName": "styled.input",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "input",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -399,7 +399,7 @@ exports[`<Textfield /> renders correctly in disabled state 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -413,7 +413,7 @@ exports[`<Textfield /> renders correctly in disabled state 1`] = `
           "displayName": "styled.input",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "input",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -618,7 +618,7 @@ exports[`<Textfield /> renders correctly in error state 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -632,7 +632,7 @@ exports[`<Textfield /> renders correctly in error state 1`] = `
           "displayName": "styled.input",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "input",
           "toString": [Function],
           "warnTooManyClasses": [Function],
@@ -836,7 +836,7 @@ exports[`<Textfield /> renders correctly with a value 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -850,7 +850,7 @@ exports[`<Textfield /> renders correctly with a value 1`] = `
           "displayName": "styled.input",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "input",
           "toString": [Function],
           "warnTooManyClasses": [Function],

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,5 @@
 export { default as useOutsideClick } from './useOutsideClick';
 export { default as useKeyDown } from './useKeyDown';
+export { default as usePosition } from './usePosition';
+export { default as useScrollPosition } from './useScrollPosition';
+export { default as useWindowSize } from './useWindowSize';

--- a/src/hooks/usePosition/index.ts
+++ b/src/hooks/usePosition/index.ts
@@ -1,0 +1,61 @@
+import { useCallback, useState, useLayoutEffect } from 'react';
+
+interface ReturnRect {
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+}
+const getOffset = (el: any) => {
+  if (!el) {
+    return { top: 0, left: 0 };
+  }
+  const rect = el.getBoundingClientRect();
+
+  return {
+    top: rect.top, // + winY,
+    left: rect.left //  + winX
+  };
+};
+
+export const getPosition = (el: any): ReturnRect => {
+  if (!el) {
+    return { top: 0, left: 0, width: 0, height: 0 };
+  }
+  let offset = getOffset(el);
+  let parentOffset = { top: 0, left: 0 };
+
+  return {
+    top: offset.top - parentOffset.top - 0,
+    left: offset.left - parentOffset.left - 0,
+    width: el.getBoundingClientRect().width || 0,
+    height: el.getBoundingClientRect().height || 0
+  };
+};
+
+export default (ref: any): ReturnRect => {
+  let { top, width, height, left } = getPosition(ref.current);
+  let [ElementPosition, setElementPosition] = useState({
+    top,
+    left,
+    width,
+    height
+  });
+
+  const handleChangePosition = useCallback(() => {
+    if (ref && ref.current) {
+      setElementPosition(getPosition(ref.current));
+    }
+  }, [ref]);
+
+  useLayoutEffect(() => {
+    handleChangePosition();
+    window.addEventListener('resize', handleChangePosition);
+
+    return () => {
+      window.removeEventListener('resize', handleChangePosition);
+    };
+  }, [handleChangePosition, ref]);
+
+  return ElementPosition;
+};

--- a/src/hooks/usePosition/index.ts
+++ b/src/hooks/usePosition/index.ts
@@ -26,8 +26,8 @@ export const getPosition = (el: any): ReturnRect => {
   let parentOffset = { top: 0, left: 0 };
 
   return {
-    top: offset.top - parentOffset.top - 0,
-    left: offset.left - parentOffset.left - 0,
+    top: offset.top - parentOffset.top,
+    left: offset.left - parentOffset.left,
     width: el.getBoundingClientRect().width || 0,
     height: el.getBoundingClientRect().height || 0
   };

--- a/src/hooks/useScrollPosition/index.tsx
+++ b/src/hooks/useScrollPosition/index.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useRef, useLayoutEffect } from 'react';
+
+const isBrowser = typeof window !== `undefined`;
+
+function getScrollPosition({ element, useWindow }: any) {
+  if (!isBrowser) return { x: 0, y: 0 };
+
+  const target = element ? element.current : document.body;
+  const position = target.getBoundingClientRect();
+
+  return useWindow
+    ? { x: window.scrollX, y: window.scrollY }
+    : { x: position.left, y: position.top };
+}
+
+export default function useScrollPosition(
+  effect?: any,
+  deps?: any,
+  element?: any,
+  useWindow?: any,
+  wait?: any
+) {
+  const position = useRef<any>(getScrollPosition({ useWindow }));
+
+  let throttleTimeout: any = null;
+
+  const callBack = () => {
+    const currPos = getScrollPosition({ element, useWindow });
+    effect({ prevPos: position.current, currPos });
+    position.current = currPos;
+    throttleTimeout = null;
+  };
+
+  useLayoutEffect(() => {
+    const handleScroll = () => {
+      if (wait) {
+        if (throttleTimeout === null) {
+          throttleTimeout = setTimeout(callBack, wait);
+        }
+      } else {
+        callBack();
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, deps);
+}
+
+useScrollPosition.defaultProps = {
+  deps: [],
+  element: false,
+  useWindow: false,
+  wait: null
+};

--- a/src/hooks/useWindowSize/index.ts
+++ b/src/hooks/useWindowSize/index.ts
@@ -1,0 +1,29 @@
+import { useCallback, useState, useEffect } from 'react';
+
+export default () => {
+  const isClient = typeof window === 'object';
+
+  const getSize = useCallback((): number[] => {
+    return [
+      isClient ? window.innerWidth : 0,
+      isClient ? window.innerHeight : 0
+    ];
+  }, [isClient]);
+
+  const [windowSize, setWindowSize] = useState(getSize);
+
+  useEffect(() => {
+    if (!isClient) {
+      return;
+    }
+
+    const handleResize = () => {
+      setWindowSize(getSize());
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [getSize, isClient]);
+
+  return windowSize;
+};

--- a/src/molecules/Dropdown/Dropdown.test.tsx
+++ b/src/molecules/Dropdown/Dropdown.test.tsx
@@ -4,7 +4,6 @@ import { mountWithTheme } from '../../test';
 import Dropdown from './index';
 import Trigger from './DropdownTrigger';
 import Flyout from './Flyout';
-import StickyContainer from '../../util/StickyContainerV2';
 
 const OutsideDiv = () => <button>bla</button>;
 
@@ -15,7 +14,7 @@ const setup = (flyoutContainer: boolean = true, offsetTop = 0) =>
       <Dropdown
         flyoutContainer={flyoutContainer}
         label="I am a dropdown"
-        offsetTop={offsetTop}
+        offset={{ vertical: offsetTop }}
       >
         Dropdown Content
       </Dropdown>
@@ -64,15 +63,6 @@ describe('<Dropdown />', () => {
     wrapper.find(Trigger).simulate('click');
     expect(wrapper.find(Flyout)).toHaveLength(1);
     expect(wrapper.find(Flyout)).not.toHaveStyleRule('width', '200px');
-  });
-
-  it('applies an offset value to the sticky container', () => {
-    const wrapper = setup(true, 100);
-    wrapper.find(Trigger).simulate('click');
-    wrapper.update();
-
-    let stickyWrapper = wrapper.find(StickyContainer);
-    expect(stickyWrapper.children().props().offsetTop).toEqual(100);
   });
 
   it.todo('closes the flyout when clicked outside');

--- a/src/molecules/Dropdown/Dropdown.test.tsx
+++ b/src/molecules/Dropdown/Dropdown.test.tsx
@@ -4,7 +4,7 @@ import { mountWithTheme } from '../../test';
 import Dropdown from './index';
 import Trigger from './DropdownTrigger';
 import Flyout from './Flyout';
-import StickyContainer from '../../util/StickyContainer';
+import StickyContainer from '../../util/StickyContainerV2';
 
 const OutsideDiv = () => <button>bla</button>;
 

--- a/src/molecules/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/molecules/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -162,7 +162,11 @@ exports[`<Dropdown /> renders correctly 1`] = `
   <Dropdown
     flyoutContainer={true}
     label="I am a dropdown"
-    offsetTop={0}
+    offset={
+      Object {
+        "vertical": 0,
+      }
+    }
   >
     <styled.div
       onClick={[Function]}

--- a/src/molecules/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/molecules/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -173,7 +173,7 @@ exports[`<Dropdown /> renders correctly 1`] = `
             "$$typeof": Symbol(react.forward_ref),
             "attrs": Array [],
             "componentStyle": ComponentStyle {
-              "componentId": "sc-bwzfXH",
+              "componentId": "sc-htpNat",
               "isStatic": true,
               "lastClassName": "c0",
               "rules": Array [
@@ -192,7 +192,7 @@ exports[`<Dropdown /> renders correctly 1`] = `
             "displayName": "styled.div",
             "foldedComponentIds": Array [],
             "render": [Function],
-            "styledComponentId": "sc-bwzfXH",
+            "styledComponentId": "sc-htpNat",
             "target": "div",
             "toString": [Function],
             "warnTooManyClasses": [Function],

--- a/src/molecules/Dropdown/index.tsx
+++ b/src/molecules/Dropdown/index.tsx
@@ -1,25 +1,17 @@
 import React, { useState, useRef } from 'react';
 
 import { StickyContainerV2, PortalComponent } from '../../util/index';
+import { StickyContainerProps } from '../../util/StickyContainerV2';
 import { useOutsideClick } from '../../hooks';
 
 import Trigger from './DropdownTrigger';
 import Flyout, { FlyoutSizes } from './Flyout';
 
-interface DropdownProps {
+interface DropdownProps extends StickyContainerProps {
   label?: string;
   renderLabel?: (arg?: any) => any;
   children: any;
   size?: FlyoutSizes;
-  offsetTop?: number;
-  anchorOrigin?: {
-    vertical: string;
-    horizontal: string;
-  };
-  transformOrigin?: {
-    vertical: string;
-    horizontal: string;
-  };
   flyoutContainer?: boolean; // TODO rename to `hasFlyoutContainer` ?
   'data-qaid'?: string;
 }
@@ -36,8 +28,8 @@ const Dropdown: React.SFC<DropdownProps> = ({
     vertical: 'top',
     horizontal: 'left'
   },
+  offset,
   size,
-  offsetTop,
   'data-qaid': qaId
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -56,7 +48,7 @@ const Dropdown: React.SFC<DropdownProps> = ({
       {isOpen && (
         <PortalComponent dom={document.body}>
           <StickyContainerV2
-            offsetTop={offsetTop}
+            offset={offset}
             anchorEl={ref}
             anchorOrigin={anchorOrigin}
             transformOrigin={transformOrigin}

--- a/src/molecules/Dropdown/index.tsx
+++ b/src/molecules/Dropdown/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 
-import { StickyContainer, PortalComponent } from '../../util/index';
+import { StickyContainerV2, PortalComponent } from '../../util/index';
 import { useOutsideClick } from '../../hooks';
 
 import Trigger from './DropdownTrigger';
@@ -12,6 +12,14 @@ interface DropdownProps {
   children: any;
   size?: FlyoutSizes;
   offsetTop?: number;
+  anchorOrigin?: {
+    vertical: string;
+    horizontal: string;
+  };
+  transformOrigin?: {
+    vertical: string;
+    horizontal: string;
+  };
   flyoutContainer?: boolean; // TODO rename to `hasFlyoutContainer` ?
   'data-qaid'?: string;
 }
@@ -20,6 +28,14 @@ const Dropdown: React.SFC<DropdownProps> = ({
   renderLabel,
   children,
   flyoutContainer,
+  anchorOrigin = {
+    vertical: 'bottom',
+    horizontal: 'left'
+  },
+  transformOrigin = {
+    vertical: 'top',
+    horizontal: 'left'
+  },
   size,
   offsetTop,
   'data-qaid': qaId
@@ -39,7 +55,12 @@ const Dropdown: React.SFC<DropdownProps> = ({
 
       {isOpen && (
         <PortalComponent dom={document.body}>
-          <StickyContainer offsetTop={offsetTop} stickToEl={ref.current}>
+          <StickyContainerV2
+            offsetTop={offsetTop}
+            anchorEl={ref}
+            anchorOrigin={anchorOrigin}
+            transformOrigin={transformOrigin}
+          >
             <Flyout
               flyoutContainer={flyoutContainer}
               size={size}
@@ -47,7 +68,7 @@ const Dropdown: React.SFC<DropdownProps> = ({
             >
               {children}
             </Flyout>
-          </StickyContainer>
+          </StickyContainerV2>
         </PortalComponent>
       )}
     </>

--- a/src/molecules/FormGroup/__snapshots__/FormGroup.test.tsx.snap
+++ b/src/molecules/FormGroup/__snapshots__/FormGroup.test.tsx.snap
@@ -1462,15 +1462,15 @@ exports[`<FormGroup /> renders a with an Icon 1`] = `
             "$$typeof": Symbol(react.forward_ref),
             "attrs": Array [],
             "componentStyle": ComponentStyle {
-              "componentId": "sc-jTzLTM",
+              "componentId": "sc-fjdhpX",
               "isStatic": true,
-              "lastClassName": "eCMmlJ",
+              "lastClassName": "nsimD",
               "rules": Array [],
             },
             "displayName": "styled.div",
             "foldedComponentIds": Array [],
             "render": [Function],
-            "styledComponentId": "sc-jTzLTM",
+            "styledComponentId": "sc-fjdhpX",
             "target": "div",
             "toString": [Function],
             "warnTooManyClasses": [Function],
@@ -1489,7 +1489,7 @@ exports[`<FormGroup /> renders a with an Icon 1`] = `
                   "$$typeof": Symbol(react.forward_ref),
                   "attrs": Array [],
                   "componentStyle": ComponentStyle {
-                    "componentId": "sc-VigVT",
+                    "componentId": "sc-jTzLTM",
                     "isStatic": false,
                     "lastClassName": "c0",
                     "rules": Array [
@@ -1507,7 +1507,7 @@ exports[`<FormGroup /> renders a with an Icon 1`] = `
                   "displayName": "styled.span",
                   "foldedComponentIds": Array [],
                   "render": [Function],
-                  "styledComponentId": "sc-VigVT",
+                  "styledComponentId": "sc-jTzLTM",
                   "target": "span",
                   "toString": [Function],
                   "warnTooManyClasses": [Function],
@@ -1543,7 +1543,7 @@ exports[`<FormGroup /> renders a with an Icon 1`] = `
                           "$$typeof": Symbol(react.forward_ref),
                           "attrs": Array [],
                           "componentStyle": ComponentStyle {
-                            "componentId": "sc-jzJRlG",
+                            "componentId": "sc-cSHVUG",
                             "isStatic": false,
                             "lastClassName": "c1",
                             "rules": Array [
@@ -1775,7 +1775,7 @@ exports[`<FormGroup /> renders a with an Icon 1`] = `
                           "displayName": "styled.i",
                           "foldedComponentIds": Array [],
                           "render": [Function],
-                          "styledComponentId": "sc-jzJRlG",
+                          "styledComponentId": "sc-cSHVUG",
                           "target": "i",
                           "toString": [Function],
                           "warnTooManyClasses": [Function],
@@ -1803,7 +1803,7 @@ exports[`<FormGroup /> renders a with an Icon 1`] = `
                   "$$typeof": Symbol(react.forward_ref),
                   "attrs": Array [],
                   "componentStyle": ComponentStyle {
-                    "componentId": "sc-fjdhpX",
+                    "componentId": "sc-jzJRlG",
                     "isStatic": false,
                     "lastClassName": "c2",
                     "rules": Array [
@@ -1817,7 +1817,7 @@ exports[`<FormGroup /> renders a with an Icon 1`] = `
                   "displayName": "styled.input",
                   "foldedComponentIds": Array [],
                   "render": [Function],
-                  "styledComponentId": "sc-fjdhpX",
+                  "styledComponentId": "sc-jzJRlG",
                   "target": "input",
                   "toString": [Function],
                   "warnTooManyClasses": [Function],

--- a/src/molecules/Select/__snapshots__/Input.test.tsx.snap
+++ b/src/molecules/Select/__snapshots__/Input.test.tsx.snap
@@ -459,7 +459,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
             "$$typeof": Symbol(react.forward_ref),
             "attrs": Array [],
             "componentStyle": ComponentStyle {
-              "componentId": "sc-bxivhb",
+              "componentId": "sc-ifAKCX",
               "isStatic": false,
               "lastClassName": "c0",
               "rules": Array [
@@ -473,7 +473,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
             "displayName": "styled.div",
             "foldedComponentIds": Array [],
             "render": [Function],
-            "styledComponentId": "sc-bxivhb",
+            "styledComponentId": "sc-ifAKCX",
             "target": "div",
             "toString": [Function],
             "warnTooManyClasses": [Function],
@@ -499,7 +499,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
                   "$$typeof": Symbol(react.forward_ref),
                   "attrs": Array [],
                   "componentStyle": ComponentStyle {
-                    "componentId": "sc-ifAKCX",
+                    "componentId": "sc-EHOje",
                     "isStatic": false,
                     "lastClassName": "c1",
                     "rules": Array [
@@ -513,7 +513,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
                   "displayName": "styled.input",
                   "foldedComponentIds": Array [],
                   "render": [Function],
-                  "styledComponentId": "sc-ifAKCX",
+                  "styledComponentId": "sc-EHOje",
                   "target": "input",
                   "toString": [Function],
                   "warnTooManyClasses": [Function],
@@ -541,7 +541,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
                   "$$typeof": Symbol(react.forward_ref),
                   "attrs": Array [],
                   "componentStyle": ComponentStyle {
-                    "componentId": "sc-htpNat",
+                    "componentId": "sc-bxivhb",
                     "isStatic": false,
                     "lastClassName": "c2",
                     "rules": Array [
@@ -556,7 +556,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
                   "displayName": "styled.button",
                   "foldedComponentIds": Array [],
                   "render": [Function],
-                  "styledComponentId": "sc-htpNat",
+                  "styledComponentId": "sc-bxivhb",
                   "target": "button",
                   "toString": [Function],
                   "warnTooManyClasses": [Function],
@@ -582,7 +582,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
                           "$$typeof": Symbol(react.forward_ref),
                           "attrs": Array [],
                           "componentStyle": ComponentStyle {
-                            "componentId": "sc-bwzfXH",
+                            "componentId": "sc-htpNat",
                             "isStatic": false,
                             "lastClassName": "c3",
                             "rules": Array [
@@ -814,7 +814,7 @@ exports[`Select <Input /> it renders correctly 1`] = `
                           "displayName": "styled.i",
                           "foldedComponentIds": Array [],
                           "render": [Function],
-                          "styledComponentId": "sc-bwzfXH",
+                          "styledComponentId": "sc-htpNat",
                           "target": "i",
                           "toString": [Function],
                           "warnTooManyClasses": [Function],

--- a/src/molecules/Select/__snapshots__/Menu.test.tsx.snap
+++ b/src/molecules/Select/__snapshots__/Menu.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`Select <Menu /> it renders correctly 1`] = `
           "$$typeof": Symbol(react.forward_ref),
           "attrs": Array [],
           "componentStyle": ComponentStyle {
-            "componentId": "sc-bwzfXH",
+            "componentId": "sc-htpNat",
             "isStatic": false,
             "lastClassName": "c0",
             "rules": Array [
@@ -185,7 +185,7 @@ exports[`Select <Menu /> it renders correctly 1`] = `
           "displayName": "styled.ul",
           "foldedComponentIds": Array [],
           "render": [Function],
-          "styledComponentId": "sc-bwzfXH",
+          "styledComponentId": "sc-htpNat",
           "target": "ul",
           "toString": [Function],
           "warnTooManyClasses": [Function],

--- a/src/molecules/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/molecules/Select/__snapshots__/Select.test.tsx.snap
@@ -789,7 +789,7 @@ exports[`Select renders correctly 1`] = `
               "$$typeof": Symbol(react.forward_ref),
               "attrs": Array [],
               "componentStyle": ComponentStyle {
-                "componentId": "sc-bxivhb",
+                "componentId": "sc-ifAKCX",
                 "isStatic": false,
                 "lastClassName": "c0",
                 "rules": Array [
@@ -803,7 +803,7 @@ exports[`Select renders correctly 1`] = `
               "displayName": "styled.div",
               "foldedComponentIds": Array [],
               "render": [Function],
-              "styledComponentId": "sc-bxivhb",
+              "styledComponentId": "sc-ifAKCX",
               "target": "div",
               "toString": [Function],
               "warnTooManyClasses": [Function],
@@ -848,7 +848,7 @@ exports[`Select renders correctly 1`] = `
                     "$$typeof": Symbol(react.forward_ref),
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "sc-ifAKCX",
+                      "componentId": "sc-EHOje",
                       "isStatic": false,
                       "lastClassName": "c1",
                       "rules": Array [
@@ -862,7 +862,7 @@ exports[`Select renders correctly 1`] = `
                     "displayName": "styled.input",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "sc-ifAKCX",
+                    "styledComponentId": "sc-EHOje",
                     "target": "input",
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -890,7 +890,7 @@ exports[`Select renders correctly 1`] = `
                     "$$typeof": Symbol(react.forward_ref),
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "sc-htpNat",
+                      "componentId": "sc-bxivhb",
                       "isStatic": false,
                       "lastClassName": "c2",
                       "rules": Array [
@@ -905,7 +905,7 @@ exports[`Select renders correctly 1`] = `
                     "displayName": "styled.button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "sc-htpNat",
+                    "styledComponentId": "sc-bxivhb",
                     "target": "button",
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -931,7 +931,7 @@ exports[`Select renders correctly 1`] = `
                             "$$typeof": Symbol(react.forward_ref),
                             "attrs": Array [],
                             "componentStyle": ComponentStyle {
-                              "componentId": "sc-bwzfXH",
+                              "componentId": "sc-htpNat",
                               "isStatic": false,
                               "lastClassName": "c3",
                               "rules": Array [
@@ -1163,7 +1163,7 @@ exports[`Select renders correctly 1`] = `
                             "displayName": "styled.i",
                             "foldedComponentIds": Array [],
                             "render": [Function],
-                            "styledComponentId": "sc-bwzfXH",
+                            "styledComponentId": "sc-htpNat",
                             "target": "i",
                             "toString": [Function],
                             "warnTooManyClasses": [Function],

--- a/src/util/StickyContainerV2/calculator.test.ts
+++ b/src/util/StickyContainerV2/calculator.test.ts
@@ -1,0 +1,68 @@
+import { calcElCenter, calculateContainerPosition } from './calculator';
+
+describe('<StickyContainerV2 />', () => {
+  it('calculates the center of an element', () => {
+    expect(calcElCenter({ width: 100, height: 50, x: 200, y: 200 })).toEqual([
+      250,
+      175
+    ]);
+  });
+
+  describe('calculateContainerPosition', () => {
+    const windowSize = [1024, 768];
+    const StickToDomElement = {
+      width: 100,
+      height: 50,
+      x: 200,
+      y: 500
+    };
+    const PopoverDom = {
+      width: 200,
+      height: 100
+    };
+
+    it('calculates the correct position for "top" positioning', () => {
+      const pos = calculateContainerPosition(
+        windowSize,
+        StickToDomElement,
+        'top',
+        PopoverDom
+      );
+
+      expect(pos).toEqual({ x: 150, y: 400, width: 200, height: 100 });
+    });
+
+    it('calculates the correct position for "bottom" positioning', () => {
+      const pos = calculateContainerPosition(
+        windowSize,
+        StickToDomElement,
+        'bottom',
+        PopoverDom
+      );
+
+      expect(pos).toEqual({ x: 150, y: 550, width: 200, height: 100 });
+    });
+
+    it('calculates the correct position for "left" positioning', () => {
+      const pos = calculateContainerPosition(
+        windowSize,
+        StickToDomElement,
+        'left',
+        PopoverDom
+      );
+
+      expect(pos).toEqual({ x: 0, y: 475, width: 200, height: 100 });
+    });
+
+    it('calculates the correct position for "right" positioning', () => {
+      const pos = calculateContainerPosition(
+        windowSize,
+        StickToDomElement,
+        'right',
+        PopoverDom
+      );
+
+      expect(pos).toEqual({ x: 300, y: 475, width: 200, height: 100 });
+    });
+  });
+});

--- a/src/util/StickyContainerV2/calculator.test.ts
+++ b/src/util/StickyContainerV2/calculator.test.ts
@@ -1,5 +1,39 @@
 import { calcElCenter, calculateContainerPosition } from './calculator';
 
+const windowSize = [1024, 768];
+const genStickTo = (props: number[]) => ({
+  width: props[0],
+  height: props[1],
+  left: props[2],
+  top: props[3]
+});
+
+const Popover = {
+  width: 100,
+  height: 100
+};
+
+const genTestCase = (
+  title: string,
+  Dom: any,
+  origin: any,
+  transform: any,
+  expected: any
+) =>
+  it(title, () => {
+    const pos = calculateContainerPosition(
+      windowSize,
+      Dom,
+      origin,
+      transform || {},
+      Popover
+    );
+
+    Object.keys(expected).map(key => {
+      expect(pos).toHaveProperty(key, expected[key]);
+    });
+  });
+
 describe('<StickyContainerV2 />', () => {
   it('calculates the center of an element', () => {
     expect(
@@ -8,60 +42,58 @@ describe('<StickyContainerV2 />', () => {
   });
 
   describe('calculateContainerPosition', () => {
-    const windowSize = [1024, 768];
-    const StickToDomElement = {
-      width: 100,
-      height: 50,
-      left: 200,
-      top: 500
-    };
-    const PopoverDom = {
-      width: 200,
-      height: 100
-    };
+    const StickTo = genStickTo([100, 100, 200, 200]);
 
-    it('calculates the correct position for "top" positioning', () => {
-      const pos = calculateContainerPosition(
-        windowSize,
-        StickToDomElement,
-        'top',
-        PopoverDom
-      );
+    const cases = [
+      ['top', 'top', 200],
+      ['top', 'center', 150],
+      ['top', 'bottom', 100],
+      ['center', 'top', 250],
+      ['center', 'center', 200],
+      ['center', 'bottom', 150],
+      ['bottom', 'top', 300],
+      ['bottom', 'center', 250],
+      ['bottom', 'bottom', 200]
+    ];
 
-      expect(pos).toEqual({ x: 150, y: 400, width: 200, height: 100 });
+    const horizontalCases = [
+      ['left', 'left', 200],
+      ['left', 'center', 150],
+      ['left', 'right', 100],
+      ['center', 'left', 250],
+      ['center', 'center', 200],
+      ['center', 'right', 150],
+      ['right', 'left', 300],
+      ['right', 'center', 250],
+      ['right', 'right', 200]
+    ];
+
+    describe('vertical alignment', () => {
+      cases.forEach((c: any) => {
+        genTestCase(
+          `calculates correct position "${c[0]}" with transform origin ${c[1]}`,
+          StickTo,
+          { vertical: c[0] },
+          { vertical: c[1] },
+          {
+            y: c[2]
+          }
+        );
+      });
     });
 
-    it('calculates the correct position for "bottom" positioning', () => {
-      const pos = calculateContainerPosition(
-        windowSize,
-        StickToDomElement,
-        'bottom',
-        PopoverDom
-      );
-
-      expect(pos).toEqual({ x: 150, y: 550, width: 200, height: 100 });
-    });
-
-    it('calculates the correct position for "left" positioning', () => {
-      const pos = calculateContainerPosition(
-        windowSize,
-        StickToDomElement,
-        'left',
-        PopoverDom
-      );
-
-      expect(pos).toEqual({ x: 0, y: 475, width: 200, height: 100 });
-    });
-
-    it('calculates the correct position for "right" positioning', () => {
-      const pos = calculateContainerPosition(
-        windowSize,
-        StickToDomElement,
-        'right',
-        PopoverDom
-      );
-
-      expect(pos).toEqual({ x: 300, y: 475, width: 200, height: 100 });
+    describe('horizontal alignment', () => {
+      horizontalCases.forEach((c: any) => {
+        genTestCase(
+          `calculates correct position "${c[0]}" with transform origin ${c[1]}`,
+          StickTo,
+          { horizontal: c[0] },
+          { horizontal: c[1] },
+          {
+            x: c[2]
+          }
+        );
+      });
     });
   });
 });

--- a/src/util/StickyContainerV2/calculator.test.ts
+++ b/src/util/StickyContainerV2/calculator.test.ts
@@ -2,10 +2,9 @@ import { calcElCenter, calculateContainerPosition } from './calculator';
 
 describe('<StickyContainerV2 />', () => {
   it('calculates the center of an element', () => {
-    expect(calcElCenter({ width: 100, height: 50, x: 200, y: 200 })).toEqual([
-      250,
-      175
-    ]);
+    expect(
+      calcElCenter({ width: 100, height: 50, left: 200, top: 200 })
+    ).toEqual([250, 175]);
   });
 
   describe('calculateContainerPosition', () => {
@@ -13,8 +12,8 @@ describe('<StickyContainerV2 />', () => {
     const StickToDomElement = {
       width: 100,
       height: 50,
-      x: 200,
-      y: 500
+      left: 200,
+      top: 500
     };
     const PopoverDom = {
       width: 200,

--- a/src/util/StickyContainerV2/calculator.test.ts
+++ b/src/util/StickyContainerV2/calculator.test.ts
@@ -95,5 +95,59 @@ describe('<StickyContainerV2 />', () => {
         );
       });
     });
+
+    describe('boundary awareness', () => {
+      it('sticks to the left side of the screen if the container would run out', () => {
+        const pos = calculateContainerPosition(
+          [350, 500],
+          StickTo,
+          { horizontal: 'left' },
+          { horizontal: 'right' },
+          { width: 250, height: 100 }
+        );
+
+        expect(pos).toHaveProperty('x', 0);
+      });
+
+      it('sticks to the right side of the screen if the container would run out', () => {
+        const pos = calculateContainerPosition(
+          [350, 500],
+          StickTo,
+          { horizontal: 'right' },
+          { horizontal: 'left' },
+          { width: 250, height: 100 }
+        );
+
+        expect(pos).toHaveProperty('x', 100);
+      });
+    });
+
+    describe('offset', () => {
+      it('adds a vertical offset to the container', () => {
+        const pos = calculateContainerPosition(
+          windowSize,
+          StickTo,
+          { horizontal: 'right' },
+          { horizontal: 'left' },
+          { width: 100, height: 100 },
+          { vertical: 100 }
+        );
+
+        expect(pos).toHaveProperty('y', 300);
+      });
+
+      it('adds a horizontal offset to the container', () => {
+        const pos = calculateContainerPosition(
+          windowSize,
+          StickTo,
+          { horizontal: 'right' },
+          { horizontal: 'left' },
+          { width: 100, height: 100 },
+          { horizontal: 100 }
+        );
+
+        expect(pos).toHaveProperty('x', 400);
+      });
+    });
   });
 });

--- a/src/util/StickyContainerV2/calculator.ts
+++ b/src/util/StickyContainerV2/calculator.ts
@@ -6,8 +6,8 @@ type WindowSize = number[];
 interface AnchorEl {
   width: number;
   height: number;
-  x: number;
-  y: number;
+  left: number;
+  top: number;
 }
 
 type Position = 'top' | 'bottom' | 'left' | 'right';
@@ -19,7 +19,10 @@ interface PopoverDomEl {
 
 // Calculate an elements center coordinates based on top/left position and width/height
 export const calcElCenter = (anchorEl: AnchorEl) => {
-  return [anchorEl.x + anchorEl.width / 2, anchorEl.y - anchorEl.height / 2];
+  return [
+    anchorEl.left + anchorEl.width / 2,
+    anchorEl.top - anchorEl.height / 2
+  ];
 };
 
 export const calculateContainerPosition = (
@@ -34,20 +37,20 @@ export const calculateContainerPosition = (
   let popoverY = 0;
 
   if (position === 'top') {
-    popoverY = anchorEl.y - popoverEl.height;
+    popoverY = anchorEl.top - popoverEl.height;
   }
   if (position === 'bottom') {
-    popoverY = anchorEl.y + anchorEl.height;
+    popoverY = anchorEl.top + anchorEl.height;
   }
 
   if (position === 'left') {
-    popoverY = anchorEl.y + anchorEl.height / 2 - popoverEl.height / 2;
-    popoverX = anchorEl.x - anchorEl.width - anchorEl.width;
+    popoverY = anchorEl.top + anchorEl.height / 2 - popoverEl.height / 2;
+    popoverX = anchorEl.left - anchorEl.width - anchorEl.width;
   }
 
   if (position === 'right') {
-    popoverY = anchorEl.y + anchorEl.height / 2 - popoverEl.height / 2;
-    popoverX = anchorEl.x + anchorEl.width;
+    popoverY = anchorEl.top + anchorEl.height / 2 - popoverEl.height / 2;
+    popoverX = anchorEl.left + anchorEl.width;
   }
 
   return {

--- a/src/util/StickyContainerV2/calculator.ts
+++ b/src/util/StickyContainerV2/calculator.ts
@@ -2,7 +2,6 @@
  * Calculate the position of the container
  */
 type WindowSize = number[];
-
 interface AnchorEl {
   width: number;
   height: number;
@@ -11,6 +10,16 @@ interface AnchorEl {
 }
 
 type Position = 'top' | 'bottom' | 'left' | 'right';
+
+interface AnchorOrigin {
+  vertical?: string;
+  horizontal?: string;
+}
+
+interface TransformOrigin {
+  vertical?: string;
+  horizontal?: string;
+}
 
 interface PopoverDomEl {
   width: number;
@@ -28,29 +37,101 @@ export const calcElCenter = (anchorEl: AnchorEl) => {
 export const calculateContainerPosition = (
   windowSize: WindowSize,
   anchorEl: AnchorEl,
-  position: Position,
+  anchorOrigin: AnchorOrigin,
+  transformOrigin: TransformOrigin,
   popoverEl: PopoverDomEl
 ) => {
   const anchorElCenter = calcElCenter(anchorEl);
 
-  let popoverX = anchorElCenter[0] - popoverEl.width / 2;
+  let popoverX = 0;
   let popoverY = 0;
 
-  if (position === 'top') {
-    popoverY = anchorEl.top - popoverEl.height;
-  }
-  if (position === 'bottom') {
-    popoverY = anchorEl.top + anchorEl.height;
+  const { vertical = 'bottom', horizontal = 'left' } = anchorOrigin;
+  const {
+    vertical: transformVertical = 'bottom',
+    horizontal: transformHorizontal = 'right'
+  } = transformOrigin;
+
+  const verticalTop = anchorEl.top - popoverEl.height;
+  const verticalCenter =
+    anchorEl.top + anchorEl.height / 2 - popoverEl.height / 2;
+  const verticalBottom = anchorEl.top + anchorEl.height;
+
+  const horizontalLeft = anchorEl.left; // - anchorEl.width - anchorEl.width;
+  const horizontalCenter =
+    anchorEl.left + anchorEl.width / 2 - popoverEl.width / 2;
+  const horizontalRight = anchorEl.left + anchorEl.width;
+
+  if (vertical === 'top') {
+    popoverY = verticalTop;
+
+    if (transformVertical === 'top') {
+      popoverY += popoverEl.height;
+    }
+
+    if (transformVertical === 'center') {
+      popoverY += popoverEl.height / 2;
+    }
   }
 
-  if (position === 'left') {
-    popoverY = anchorEl.top + anchorEl.height / 2 - popoverEl.height / 2;
-    popoverX = anchorEl.left - anchorEl.width - anchorEl.width;
+  if (vertical === 'center') {
+    popoverY = verticalCenter;
+
+    if (transformVertical === 'top') {
+      popoverY += popoverEl.height / 2;
+    }
+
+    if (transformVertical === 'bottom') {
+      popoverY -= popoverEl.height / 2;
+    }
   }
 
-  if (position === 'right') {
-    popoverY = anchorEl.top + anchorEl.height / 2 - popoverEl.height / 2;
-    popoverX = anchorEl.left + anchorEl.width;
+  if (vertical === 'bottom') {
+    popoverY = verticalBottom;
+
+    if (transformVertical === 'center') {
+      popoverY -= popoverEl.height / 2;
+    }
+
+    if (transformVertical === 'bottom') {
+      popoverY -= popoverEl.height;
+    }
+  }
+
+  if (horizontal === 'left') {
+    popoverX = horizontalLeft;
+
+    if (transformHorizontal === 'center') {
+      popoverX -= popoverEl.width / 2;
+    }
+
+    if (transformHorizontal === 'right') {
+      popoverX -= popoverEl.width;
+    }
+  }
+
+  if (horizontal === 'center') {
+    popoverX = horizontalCenter;
+
+    if (transformHorizontal === 'left') {
+      popoverX += popoverEl.width / 2;
+    }
+
+    if (transformHorizontal === 'right') {
+      popoverX -= popoverEl.width / 2;
+    }
+  }
+
+  if (horizontal === 'right') {
+    popoverX = horizontalRight - popoverEl.width;
+
+    if (transformHorizontal === 'left') {
+      popoverX += popoverEl.width;
+    }
+
+    if (transformHorizontal === 'center') {
+      popoverX += popoverEl.width / 2;
+    }
   }
 
   return {

--- a/src/util/StickyContainerV2/calculator.ts
+++ b/src/util/StickyContainerV2/calculator.ts
@@ -1,0 +1,59 @@
+/**
+ * Calculate the position of the container
+ */
+type WindowSize = number[];
+
+interface AnchorEl {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+}
+
+type Position = 'top' | 'bottom' | 'left' | 'right';
+
+interface PopoverDomEl {
+  width: number;
+  height: number;
+}
+
+// Calculate an elements center coordinates based on top/left position and width/height
+export const calcElCenter = (anchorEl: AnchorEl) => {
+  return [anchorEl.x + anchorEl.width / 2, anchorEl.y - anchorEl.height / 2];
+};
+
+export const calculateContainerPosition = (
+  windowSize: WindowSize,
+  anchorEl: AnchorEl,
+  position: Position,
+  popoverEl: PopoverDomEl
+) => {
+  const anchorElCenter = calcElCenter(anchorEl);
+
+  let popoverX = anchorElCenter[0] - popoverEl.width / 2;
+  let popoverY = 0;
+
+  if (position === 'top') {
+    popoverY = anchorEl.y - popoverEl.height;
+  }
+  if (position === 'bottom') {
+    popoverY = anchorEl.y + anchorEl.height;
+  }
+
+  if (position === 'left') {
+    popoverY = anchorEl.y + anchorEl.height / 2 - popoverEl.height / 2;
+    popoverX = anchorEl.x - anchorEl.width - anchorEl.width;
+  }
+
+  if (position === 'right') {
+    popoverY = anchorEl.y + anchorEl.height / 2 - popoverEl.height / 2;
+    popoverX = anchorEl.x + anchorEl.width;
+  }
+
+  return {
+    x: popoverX,
+    y: popoverY,
+    width: popoverEl.width,
+    height: popoverEl.height
+  };
+};

--- a/src/util/StickyContainerV2/calculator.ts
+++ b/src/util/StickyContainerV2/calculator.ts
@@ -11,14 +11,19 @@ interface AnchorEl {
 
 type Position = 'top' | 'bottom' | 'left' | 'right';
 
-interface AnchorOrigin {
+export interface AnchorOrigin {
   vertical?: string;
   horizontal?: string;
 }
 
-interface TransformOrigin {
+export interface TransformOrigin {
   vertical?: string;
   horizontal?: string;
+}
+
+export interface Offset {
+  vertical?: number;
+  horizontal?: number;
 }
 
 interface PopoverDomEl {
@@ -39,9 +44,10 @@ export const calculateContainerPosition = (
   anchorEl: AnchorEl,
   anchorOrigin: AnchorOrigin,
   transformOrigin: TransformOrigin,
-  popoverEl: PopoverDomEl
+  popoverEl: PopoverDomEl,
+  offset?: Offset
 ) => {
-  const anchorElCenter = calcElCenter(anchorEl);
+  const [windowWidth, windowHeight] = windowSize;
 
   let popoverX = 0;
   let popoverY = 0;
@@ -57,7 +63,7 @@ export const calculateContainerPosition = (
     anchorEl.top + anchorEl.height / 2 - popoverEl.height / 2;
   const verticalBottom = anchorEl.top + anchorEl.height;
 
-  const horizontalLeft = anchorEl.left; // - anchorEl.width - anchorEl.width;
+  const horizontalLeft = anchorEl.left;
   const horizontalCenter =
     anchorEl.left + anchorEl.width / 2 - popoverEl.width / 2;
   const horizontalRight = anchorEl.left + anchorEl.width;
@@ -132,6 +138,38 @@ export const calculateContainerPosition = (
     if (transformHorizontal === 'center') {
       popoverX += popoverEl.width / 2;
     }
+  }
+
+  /**
+   * Adjust if an offset has been set
+   */
+  if (offset) {
+    if (offset.vertical) {
+      popoverY += offset.vertical;
+    }
+
+    if (offset.horizontal) {
+      popoverX += offset.horizontal;
+    }
+  }
+
+  /**
+   * Adjust the popover element position if it would run out of the screen
+   */
+  if (popoverX < 0) {
+    popoverX = 0;
+  }
+
+  if (popoverY < 0) {
+    popoverY = 0;
+  }
+
+  if (popoverX + popoverEl.width > windowWidth) {
+    popoverX = windowWidth - popoverEl.width;
+  }
+
+  if (popoverY + popoverEl.height > windowHeight) {
+    popoverY = windowHeight - popoverEl.height;
   }
 
   return {

--- a/src/util/StickyContainerV2/index.tsx
+++ b/src/util/StickyContainerV2/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled, { css } from '../../lib/styledComponents';
+
+import { calculateContainerPosition } from './calculator';
+
+const Container = styled.div<any>`
+  background: #ccc;
+  border: 1px solid #aaa;
+  width: 200px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ calculated }) => css`
+    position: fixed;
+    top: ${calculated.y}px;
+    left: ${calculated.x}px;
+  `}
+`;
+
+const StickyContainerV2: React.SFC<any> = ({
+  anchorEl,
+  position,
+  children
+}) => {
+  const windowWidth = [window.innerWidth, window.innerHeight];
+
+  if (!anchorEl) {
+    return null;
+  }
+
+  const anchor = {
+    width: 100,
+    height: 100,
+    x: 403,
+    y: 164
+  };
+
+  const popoverEl = {
+    width: 200,
+    height: 50
+  };
+
+  const pos = calculateContainerPosition(
+    windowWidth,
+    anchor,
+    position,
+    popoverEl
+  );
+
+  return <Container calculated={pos}>{children}</Container>;
+};
+
+export default StickyContainerV2;

--- a/src/util/StickyContainerV2/index.tsx
+++ b/src/util/StickyContainerV2/index.tsx
@@ -3,7 +3,18 @@ import styled from '../../lib/styledComponents';
 
 import { useScrollPosition, useWindowSize } from '../../hooks';
 import { getPosition } from '../../hooks/usePosition';
-import { calculateContainerPosition } from './calculator';
+import {
+  AnchorOrigin,
+  TransformOrigin,
+  Offset,
+  calculateContainerPosition
+} from './calculator';
+
+export interface StickyContainerProps {
+  anchorOrigin?: AnchorOrigin;
+  transformOrigin?: TransformOrigin;
+  offset?: Offset;
+}
 
 const Container = styled.div<any>`
   position: fixed;
@@ -13,6 +24,7 @@ const StickyContainerV2: React.SFC<any> = ({
   anchorEl,
   anchorOrigin,
   transformOrigin,
+  offset,
   children
 }) => {
   const popoverRef = useRef<any>();
@@ -30,13 +42,14 @@ const StickyContainerV2: React.SFC<any> = ({
           pos,
           anchorOrigin,
           transformOrigin,
-          popoverElRect
+          popoverElRect,
+          offset
         );
 
         setCalculatedPosition(calculated);
       }
     },
-    [popoverElRect, anchorOrigin, windowSize]
+    [windowSize, anchorOrigin, transformOrigin, popoverElRect, offset]
   );
 
   useEffect(() => {

--- a/src/util/StickyContainerV2/index.tsx
+++ b/src/util/StickyContainerV2/index.tsx
@@ -6,19 +6,13 @@ import { getPosition } from '../../hooks/usePosition';
 import { calculateContainerPosition } from './calculator';
 
 const Container = styled.div<any>`
-  background: #ccc;
-  border: 1px solid #aaa;
-  width: 200px;
-  height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   position: fixed;
 `;
 
 const StickyContainerV2: React.SFC<any> = ({
   anchorEl,
-  position,
+  anchorOrigin,
+  transformOrigin,
   children
 }) => {
   const popoverRef = useRef<any>();
@@ -34,14 +28,15 @@ const StickyContainerV2: React.SFC<any> = ({
         const calculated = calculateContainerPosition(
           windowSize,
           pos,
-          position,
+          anchorOrigin,
+          transformOrigin,
           popoverElRect
         );
 
         setCalculatedPosition(calculated);
       }
     },
-    [popoverElRect, position, windowSize]
+    [popoverElRect, anchorOrigin, windowSize]
   );
 
   useEffect(() => {
@@ -52,18 +47,27 @@ const StickyContainerV2: React.SFC<any> = ({
 
   useEffect(() => {
     updateCalculatedPosition(anchorEl);
-  }, [anchorEl, popoverElRect, position, updateCalculatedPosition, windowSize]);
+  }, [
+    anchorEl,
+    popoverElRect,
+    anchorOrigin,
+    transformOrigin,
+    updateCalculatedPosition,
+    windowSize
+  ]);
 
   useScrollPosition(() => {
     updateCalculatedPosition(anchorEl);
   });
 
+  const { y = -10000, x = -10000 } = calculatedPosition;
+
   return (
     <Container
       ref={popoverRef}
       style={{
-        top: `${calculatedPosition.y}px`,
-        left: `${calculatedPosition.x}px`
+        top: `${y}px`,
+        left: `${x}px`
       }}
     >
       {children}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -2,6 +2,7 @@ export { default as withSpacing, WithSpacingProps } from './withSpacing';
 export { default as withShadow } from './withShadow';
 export { default as PortalComponent } from './PortalComponent';
 export { default as StickyContainer } from './StickyContainer';
+export { default as StickyContainerV2 } from './StickyContainerV2';
 export {
   default as withTypography,
   WithTypographyProps

--- a/storybook/stories/Dropdown.stories.tsx
+++ b/storybook/stories/Dropdown.stories.tsx
@@ -36,7 +36,7 @@ storiesOf('Dropdown', module)
     <>
       <h1>Dropdown with Offset</h1>
       <Dropdown
-        offsetTop={55}
+        offset={{ vertical: 55 }}
         flyoutContainer={false}
         renderLabel={isOpen => (
           <>
@@ -66,7 +66,7 @@ storiesOf('Dropdown', module)
       <h1>Without Flyout Container</h1>
       <Dropdown
         flyoutContainer={false}
-        offsetTop={0}
+        offset={{ vertical: 50 }}
         renderLabel={isOpen => (
           <PrimaryButton>{isOpen ? 'Open' : 'Close'}</PrimaryButton>
         )}

--- a/storybook/stories/Dropdown.stories.tsx
+++ b/storybook/stories/Dropdown.stories.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
+import {
+  withKnobs,
+  text,
+  number,
+  boolean,
+  select
+} from '@storybook/addon-knobs';
 import { Icon, Dropdown, Menu, Option, Select, PrimaryButton } from '../../src';
 import cities from '../helpers/cities';
 
@@ -9,23 +15,26 @@ const mockClick = () => {
   console.log('dog');
 };
 
+const positions = ['top', 'right', 'bottom', 'left'];
+
 storiesOf('Dropdown', module)
   .addDecorator(withKnobs)
   .add('Default', () => (
     <>
       <h1>Dropdown</h1>
 
-      <Dropdown label="I am a clickable label">
+      <Dropdown label="Click me to open the dropdown">
         <b>A Dropdown</b>
         <p>
           A dropdown component can be used to display help information or a
           short list of options
         </p>
       </Dropdown>
-
-      <br />
-      <br />
-
+    </>
+  ))
+  .add('With Offset', () => (
+    <>
+      <h1>Dropdown with Offset</h1>
       <Dropdown
         offsetTop={55}
         flyoutContainer={false}
@@ -50,10 +59,11 @@ storiesOf('Dropdown', module)
           ))}
         </Menu>
       </Dropdown>
-
-      <br />
-      <br />
-
+    </>
+  ))
+  .add('Without Flyout Container', () => (
+    <>
+      <h1>Without Flyout Container</h1>
       <Dropdown
         flyoutContainer={false}
         offsetTop={0}
@@ -61,7 +71,9 @@ storiesOf('Dropdown', module)
           <PrimaryButton>{isOpen ? 'Open' : 'Close'}</PrimaryButton>
         )}
       >
-        <p>I am the contents of a dropdown without a flyout container</p>
+        <p style={{ width: '200px' }}>
+          I am the contents of a dropdown without a flyout container
+        </p>
       </Dropdown>
     </>
   ));

--- a/storybook/stories/Header.stories.tsx
+++ b/storybook/stories/Header.stories.tsx
@@ -25,7 +25,7 @@ storiesOf('Header', module)
           <Navbar.ItemContainer>
             <Dropdown
               flyoutContainer={false}
-              offsetTop={-2}
+              offset={{ vertical: -2 }}
               renderLabel={isOpen => (
                 <OutlineButton small color={'white'}>
                   <span style={{ marginRight: '5px', color: 'inherit' }}>
@@ -59,7 +59,7 @@ storiesOf('Header', module)
             <Navbar.Item>Host</Navbar.Item>
             <Dropdown
               flyoutContainer={false}
-              offsetTop={10}
+              offset={{ vertical: 10 }}
               renderLabel={isOpen => (
                 <Navbar.Item>
                   <span style={{ marginRight: '5px', color: 'inherit' }}>

--- a/storybook/stories/StickyContainer.stories.tsx
+++ b/storybook/stories/StickyContainer.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import {
@@ -12,13 +12,28 @@ import {
 
 import { StickyContainerV2 } from '../../src';
 
-const Anchor = styled.div`
+const Anchor = styled.div<any>`
   background: #ccc;
   width: 100px;
   height: 100px;
   position: absolute;
   top: calc(50% - 50px);
   left: calc(50% - 50px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  ${({ fixed }) =>
+    fixed &&
+    css`
+      position: fixed;
+    `}
+`;
+
+const StickyStyle = styled.div`
+  width: 200px;
+  height: 50px;
+  background: #bbb;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -29,12 +44,37 @@ const Example = () => {
 
   return (
     <div style={{ height: '5000px' }}>
-      <Anchor ref={ref}>Anchor</Anchor>
+      <Anchor ref={ref} fixed={boolean('Fix Anchor', false)}>
+        Anchor
+      </Anchor>
       <StickyContainerV2
         anchorEl={ref}
-        position={select('Position', ['top', 'bottom', 'left', 'right'], 'top')}
+        anchorOrigin={{
+          vertical: select(
+            'Vertical Origin',
+            ['top', 'center', 'bottom'],
+            'top'
+          ),
+          horizontal: select(
+            'Horizontal Origin',
+            ['left', 'center', 'right'],
+            'left'
+          )
+        }}
+        transformOrigin={{
+          vertical: select(
+            'Transform Vertical Origin',
+            ['top', 'center', 'bottom'],
+            'top'
+          ),
+          horizontal: select(
+            'Transform Horizontal Origin',
+            ['left', 'center', 'right'],
+            'left'
+          )
+        }}
       >
-        I am Sticky
+        <StickyStyle>I am Sticky</StickyStyle>
       </StickyContainerV2>
     </div>
   );

--- a/storybook/stories/StickyContainer.stories.tsx
+++ b/storybook/stories/StickyContainer.stories.tsx
@@ -16,7 +16,7 @@ const Anchor = styled.div`
   background: #ccc;
   width: 100px;
   height: 100px;
-  position: fixed;
+  position: absolute;
   top: calc(50% - 50px);
   left: calc(50% - 50px);
   display: flex;
@@ -28,7 +28,7 @@ const Example = () => {
   const ref = React.useRef<any>();
 
   return (
-    <div>
+    <div style={{ height: '5000px' }}>
       <Anchor ref={ref}>Anchor</Anchor>
       <StickyContainerV2
         anchorEl={ref}

--- a/storybook/stories/StickyContainer.stories.tsx
+++ b/storybook/stories/StickyContainer.stories.tsx
@@ -73,6 +73,10 @@ const Example = () => {
             'left'
           )
         }}
+        offset={{
+          vertical: number('Vertical Offset', 0),
+          horizontal: number('Horizontal Offset', 0)
+        }}
       >
         <StickyStyle>I am Sticky</StickyStyle>
       </StickyContainerV2>

--- a/storybook/stories/StickyContainer.stories.tsx
+++ b/storybook/stories/StickyContainer.stories.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import {
+  withKnobs,
+  text,
+  select,
+  number,
+  boolean
+} from '@storybook/addon-knobs';
+
+import { StickyContainerV2 } from '../../src';
+
+const Anchor = styled.div`
+  background: #ccc;
+  width: 100px;
+  height: 100px;
+  position: fixed;
+  top: calc(50% - 50px);
+  left: calc(50% - 50px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const Example = () => {
+  const ref = React.useRef<any>();
+
+  return (
+    <div>
+      <Anchor ref={ref}>Anchor</Anchor>
+      <StickyContainerV2
+        anchorEl={ref}
+        position={select('Position', ['top', 'bottom', 'left', 'right'], 'top')}
+      >
+        I am Sticky
+      </StickyContainerV2>
+    </div>
+  );
+};
+
+storiesOf('Sticky Container', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => <Example />);


### PR DESCRIPTION
A new sticky container that has more configuration options and can adjust to window size by automatically flipping direction and moving according to how much window space there is.

New Sticky Container can be used like this
```js
<StickyContainerV2
  anchorEl={ref}
  anchorOrigin={{
    vertical: 'top',
    horizontal: 'left'
  }}
  transformOrigin={{
    vertical: 'bottom',
    horizontal: 'right'
  }}
>
  Sticky Content
</StickyContainerV2>
```

Inspiration for anchorOrigin and transformOrigin taken from material ui.


**Things left to do** 
- Responsiveness / auto flip side if not enough space etc
- Offset prop (talk to Dan, is it actually needed?)
- Documentation
- Test coverage