### PR TITLE
Add absolute and transparent props to Navbar component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/molecules/Navbar/NavbarContainer.test.tsx
+++ b/src/molecules/Navbar/NavbarContainer.test.tsx
@@ -38,4 +38,44 @@ describe('Navbar', () => {
       });
     });
   });
+
+  describe('<Navbar transparent={true} />', () => {
+    it('has the correct style rules', () => {
+      const wrapper = mountWithTheme(
+        <Navbar transparent={true}>children</Navbar>
+      );
+
+      expect(wrapper).toHaveStyleRule('height', '62px');
+      expect(wrapper).toHaveStyleRule('background', '#000');
+
+      expect(wrapper).toHaveStyleRule('height', '74px', {
+        media: '(min-width:768px)'
+      });
+      expect(wrapper).toHaveStyleRule('background', 'transparent', {
+        media: '(min-width:768px)'
+      });
+      expect(wrapper).toHaveStyleRule('height', '84px', {
+        media: '(min-width:992px)'
+      });
+    });
+  });
+
+  describe('<Navbar absolutePosition={true} />', () => {
+    it('has the correct style rules', () => {
+      const wrapper = mountWithTheme(
+        <Navbar absolutePosition={true}>children</Navbar>
+      );
+
+      expect(wrapper).toHaveStyleRule('height', '62px');
+      expect(wrapper).toHaveStyleRule('background', '#000');
+      expect(wrapper).toHaveStyleRule('position', 'absolute');
+
+      expect(wrapper).toHaveStyleRule('height', '74px', {
+        media: '(min-width:768px)'
+      });
+      expect(wrapper).toHaveStyleRule('height', '84px', {
+        media: '(min-width:992px)'
+      });
+    });
+  });
 });

--- a/src/molecules/Navbar/NavbarContainer.test.tsx
+++ b/src/molecules/Navbar/NavbarContainer.test.tsx
@@ -19,9 +19,11 @@ describe('Navbar', () => {
     });
   });
 
-  describe('<Navbar fixed={true} />', () => {
+  describe('<Navbar position="fixed" />', () => {
     it('has the correct style rules', () => {
-      const wrapper = mountWithTheme(<Navbar fixed={true}>children</Navbar>);
+      const wrapper = mountWithTheme(
+        <Navbar position="fixed">children</Navbar>
+      );
 
       expect(wrapper).toHaveStyleRule('height', '62px');
       expect(wrapper).toHaveStyleRule('background', '#000');
@@ -60,10 +62,10 @@ describe('Navbar', () => {
     });
   });
 
-  describe('<Navbar absolutePosition={true} />', () => {
+  describe('<Navbar position="absolute" />', () => {
     it('has the correct style rules', () => {
       const wrapper = mountWithTheme(
-        <Navbar absolutePosition={true}>children</Navbar>
+        <Navbar position="absolute">children</Navbar>
       );
 
       expect(wrapper).toHaveStyleRule('height', '62px');

--- a/src/molecules/Navbar/NavbarContainer.tsx
+++ b/src/molecules/Navbar/NavbarContainer.tsx
@@ -17,12 +17,13 @@ export default styled.div<NavbarContainerProps>`
     align-items: center;
     justify-content: center;
     z-index: ${theme.zIndex.navbar};
-      ${position &&
+      ${position === 'absolute' &&
         css`
-          position: ${position};
+          position: absolute;
         `}
       ${position === 'fixed' &&
         css`
+          position: fixed;
           top: 0;
           left: 0;
           right: 0;

--- a/src/molecules/Navbar/NavbarContainer.tsx
+++ b/src/molecules/Navbar/NavbarContainer.tsx
@@ -1,13 +1,14 @@
 import styled, { css } from '../../lib/styledComponents';
 
+export type NavbarPositions = 'absolute' | 'fixed';
+
 interface NavbarContainerProps {
-  absolutePosition?: boolean;
-  fixed?: boolean;
+  position?: NavbarPositions;
   transparent?: boolean;
 }
 
 export default styled.div<NavbarContainerProps>`
-  ${({ theme, fixed, transparent, absolutePosition }) => css`
+  ${({ theme, position, transparent }) => css`
     width: 100%;
     height: ${theme.dimensions.navbarHeight.xs};
     background: #000;
@@ -16,13 +17,12 @@ export default styled.div<NavbarContainerProps>`
     align-items: center;
     justify-content: center;
     z-index: ${theme.zIndex.navbar};
-      ${absolutePosition &&
+      ${position &&
         css`
-          position: absolute;
+          position: ${position};
         `}
-      ${fixed &&
+      ${position === 'fixed' &&
         css`
-          position: fixed;
           top: 0;
           left: 0;
           right: 0;

--- a/src/molecules/Navbar/NavbarContainer.tsx
+++ b/src/molecules/Navbar/NavbarContainer.tsx
@@ -1,11 +1,13 @@
 import styled, { css } from '../../lib/styledComponents';
 
 interface NavbarContainerProps {
+  absolutePosition?: boolean;
   fixed?: boolean;
+  transparent?: boolean;
 }
 
 export default styled.div<NavbarContainerProps>`
-  ${({ theme, fixed }) => css`
+  ${({ theme, fixed, transparent, absolutePosition }) => css`
     width: 100%;
     height: ${theme.dimensions.navbarHeight.xs};
     background: #000;
@@ -14,21 +16,25 @@ export default styled.div<NavbarContainerProps>`
     align-items: center;
     justify-content: center;
     z-index: ${theme.zIndex.navbar};
-
-    ${fixed &&
-      css`
-        position: fixed;
-        top: 0;
-        left: 0;
-        right: 0;
+      ${absolutePosition &&
+        css`
+          position: absolute;
+        `}
+      ${fixed &&
+        css`
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+        `}
+      ${transparent &&
+        theme.media.md`
+        background: transparent;
       `}
-
-    ${theme.media.md`
+      ${theme.media.md`
       height: ${theme.dimensions.navbarHeight.md};
-    `}
-
-    ${theme.media.lg`
+    `} ${theme.media.lg`
       height: ${theme.dimensions.navbarHeight.lg};
-    `}
+    `};
   `}
 `;

--- a/src/molecules/Navbar/README.md
+++ b/src/molecules/Navbar/README.md
@@ -28,14 +28,20 @@ icon that can expand the navbar.
 
 ## `Navbar` Props
 
-| Name          | Type         | Default         | Description                      |
-| :------------ | :-----       | :-------------- | :------------------------------- |
-| **children**  | `React.Node` |                 | The content to be rendered in the navbar
-| fixed         | `Boolean`    |                 | Whether the navbar is fixed to the top of the screen
-| invert        | `Boolean`    |                 | Whether to invert the colour of the navbar
-| logoLinkTo    | `string`     |                 | Where does clicking the logo link to
-| data-qaid     | `string`     |                 | Optional prop for testing purposes
+| Name          | Type          | Default         | Description                      |
+| :------------ | :-----        | :-------------- | :------------------------------- |
+| **children**  | `React.Node`  |                 | The content to be rendered in the navbar
+| position      | [Enum](#enum) |                 | Whether the navbar is fixed to the top of the screen or absolute positioned
+| invert        | `Boolean`     |                 | Whether to invert the colour of the navbar
+| logoLinkTo    | `string`      |                 | Where does clicking the logo link to
+| data-qaid     | `string`      |                 | Optional prop for testing purposes
 
+### Enum
+
+| position  |
+| :---      |
+| absolute  |
+| fixed     |
 
 ## `Navbar.ItemContainer` Props
 

--- a/src/molecules/Navbar/index.tsx
+++ b/src/molecules/Navbar/index.tsx
@@ -14,6 +14,8 @@ import Item from './Item';
 interface NavbarProps {
   fixed?: boolean;
   invert?: boolean;
+  transparent?: boolean;
+  absolutePosition?: boolean;
   children: any;
   logoLinkTo?: string;
   'data-qaid'?: string;
@@ -77,10 +79,22 @@ class Navbar extends React.Component<NavbarProps, NavbarState> {
 
   public render() {
     const { open } = this.state;
-    const { logoLinkTo, children, fixed, 'data-qaid': qaId } = this.props;
+    const {
+      logoLinkTo,
+      children,
+      fixed,
+      'data-qaid': qaId,
+      transparent,
+      absolutePosition
+    } = this.props;
 
     return (
-      <NavbarContainer fixed={fixed} data-qaid={qaId}>
+      <NavbarContainer
+        fixed={fixed}
+        data-qaid={qaId}
+        transparent={transparent}
+        absolutePosition={absolutePosition}
+      >
         <Container alignItems="center" justifyContent="space-between">
           <a href={logoLinkTo || '/'}>
             <Brand>

--- a/src/molecules/Navbar/index.tsx
+++ b/src/molecules/Navbar/index.tsx
@@ -4,7 +4,7 @@ import { breakPoints } from '../../theme';
 import Logo from '../../atoms/Logo';
 import Container from '../../atoms/Container';
 
-import NavbarContainer from './NavbarContainer';
+import NavbarContainer, { NavbarPositions } from './NavbarContainer';
 import CollapsibleWrapper from './Collapsible';
 import Hamburger from './CollapseIcon';
 import Brand from './Brand';
@@ -12,10 +12,9 @@ import ItemContainer from './ItemContainer';
 import Item from './Item';
 
 interface NavbarProps {
-  fixed?: boolean;
+  position?: NavbarPositions;
   invert?: boolean;
   transparent?: boolean;
-  absolutePosition?: boolean;
   children: any;
   logoLinkTo?: string;
   'data-qaid'?: string;
@@ -82,18 +81,16 @@ class Navbar extends React.Component<NavbarProps, NavbarState> {
     const {
       logoLinkTo,
       children,
-      fixed,
       'data-qaid': qaId,
       transparent,
-      absolutePosition
+      position
     } = this.props;
 
     return (
       <NavbarContainer
-        fixed={fixed}
+        position={position}
         data-qaid={qaId}
         transparent={transparent}
-        absolutePosition={absolutePosition}
       >
         <Container alignItems="center" justifyContent="space-between">
           <a href={logoLinkTo || '/'}>

--- a/storybook/stories/Navbar.stories.tsx
+++ b/storybook/stories/Navbar.stories.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
-import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
+import { withKnobs } from '@storybook/addon-knobs';
 import { BrowserRouter } from 'react-router-dom';
 
-import { Navbar } from '../../src';
+import { Navbar, HeroImage } from '../../src';
 
 storiesOf('Navbar', module)
   .addDecorator(withKnobs)
@@ -27,5 +26,29 @@ storiesOf('Navbar', module)
         <h1>Navbar Component</h1>
         <div style={{ height: '500px' }}>Scrollable Content</div>
       </div>
+    </BrowserRouter>
+  ))
+  .add('Transparent', () => (
+    <BrowserRouter>
+      <>
+        <Navbar data-qaid="navbar" fixed transparent>
+          <Navbar.ItemContainer>
+            <span style={{ color: '#fff' }}>LEFT</span>
+          </Navbar.ItemContainer>
+          <Navbar.ItemContainer align="right">
+            <Navbar.Item href="#">London</Navbar.Item>
+            <Navbar.Item href="#">Perform</Navbar.Item>
+            <Navbar.Item>Host</Navbar.Item>
+            <Navbar.Item>Your Events</Navbar.Item>
+            <Navbar.Item>Your Account</Navbar.Item>
+            <Navbar.Item>English</Navbar.Item>
+          </Navbar.ItemContainer>
+        </Navbar>
+        <HeroImage
+          height="600px"
+          imageURL="https://www.stratatiles.co.uk/wp-content/uploads/2015/04/102.jpg"
+          title="This is a title"
+        />
+      </>
     </BrowserRouter>
   ));

--- a/storybook/stories/Navbar.stories.tsx
+++ b/storybook/stories/Navbar.stories.tsx
@@ -10,7 +10,7 @@ storiesOf('Navbar', module)
   .add('Default', () => (
     <BrowserRouter>
       <div style={{ paddingTop: '100px' }}>
-        <Navbar data-qaid="navbar" fixed>
+        <Navbar data-qaid="navbar" position="fixed">
           <Navbar.ItemContainer>
             <span style={{ color: '#fff' }}>LEFT</span>
           </Navbar.ItemContainer>
@@ -31,7 +31,7 @@ storiesOf('Navbar', module)
   .add('Transparent', () => (
     <BrowserRouter>
       <>
-        <Navbar data-qaid="navbar" fixed transparent>
+        <Navbar data-qaid="navbar" position="fixed" transparent>
           <Navbar.ItemContainer>
             <span style={{ color: '#fff' }}>LEFT</span>
           </Navbar.ItemContainer>


### PR DESCRIPTION
## Description

Add two new props to make the Navbar component a bit more flexible:

- absolutePosition: sets `position: absolute`
- transparent: sets `background: transparent` when window width is >= 768px

## Links

[JIRA](https://sofarsounds.atlassian.net/browse/THEOC-339) - This is part of the work needed to create the transparent navigation we have on the /about/hosts page.