### PR TITLE
Change focus property on transparent button

### DIFF
--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
   background: transparent;
   color: #039842;
   background: #FFFFFF;
-  border-color: #FFFFFF;
+  border: none;
   color: #039842;
 }
 
@@ -85,7 +85,6 @@ exports[`Buttons Link Button renders correctly 1`] = `
 
 .c0:hover {
   color: #006721;
-  border-color: #FFFFFF;
 }
 
 .c0:hover i:before {
@@ -93,12 +92,11 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(230,247,234,0.1) border-color:#E6F7EA;
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
   background-color: #FFFFFF;
-  border-color: #FFFFFF;
 }
 
 <ThemeProvider
@@ -342,7 +340,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
   background: transparent;
   color: #039842;
   background: #FFFFFF;
-  border-color: #FFFFFF;
+  border: none;
   color: #039842;
 }
 
@@ -405,7 +403,6 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 
 .c0:hover {
   color: #006721;
-  border-color: #FFFFFF;
 }
 
 .c0:hover i:before {
@@ -413,12 +410,11 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(230,247,234,0.1) border-color:#E6F7EA;
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
   background-color: #FFFFFF;
-  border-color: #FFFFFF;
 }
 
 <ThemeProvider
@@ -668,7 +664,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
   background: transparent;
   color: #039842;
   background: #FFFFFF;
-  border-color: #FFFFFF;
+  border: none;
   color: #039842;
 }
 
@@ -760,7 +756,6 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 
 .c0:hover {
   color: #006721;
-  border-color: #FFFFFF;
 }
 
 .c0:hover i:before {
@@ -768,12 +763,11 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(230,247,234,0.1) border-color:#E6F7EA;
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
   background-color: #FFFFFF;
-  border-color: #FFFFFF;
 }
 
 <ThemeProvider

--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(16,173,82,0.01);
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
@@ -93,7 +93,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(230,247,234,0.01) border-color:#E6F7EA;
+  background-color: rgba(230,247,234,0.1) border-color:#E6F7EA;
 }
 
 .c0:disabled {
@@ -387,7 +387,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(16,173,82,0.01);
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
@@ -413,7 +413,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(230,247,234,0.01) border-color:#E6F7EA;
+  background-color: rgba(230,247,234,0.1) border-color:#E6F7EA;
 }
 
 .c0:disabled {
@@ -736,7 +736,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(16,173,82,0.01);
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
@@ -768,7 +768,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(230,247,234,0.01) border-color:#E6F7EA;
+  background-color: rgba(230,247,234,0.1) border-color:#E6F7EA;
 }
 
 .c0:disabled {
@@ -1059,7 +1059,7 @@ exports[`Buttons Outline Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(16,173,82,0.01);
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
@@ -1348,7 +1348,7 @@ exports[`Buttons Outline Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(16,173,82,0.01);
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {
@@ -1668,7 +1668,7 @@ exports[`Buttons Outline Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: rgba(16,173,82,0.01);
+  background-color: rgba(16,173,82,0.1);
 }
 
 .c0:disabled {

--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: transparent;
+  background-color: rgba(16,173,82,0.01);
 }
 
 .c0:disabled {
@@ -93,8 +93,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
-  border-color: #E6F7EA;
+  background-color: rgba(230,247,234,0.01) border-color:#E6F7EA;
 }
 
 .c0:disabled {
@@ -388,7 +387,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: transparent;
+  background-color: rgba(16,173,82,0.01);
 }
 
 .c0:disabled {
@@ -414,8 +413,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
-  border-color: #E6F7EA;
+  background-color: rgba(230,247,234,0.01) border-color:#E6F7EA;
 }
 
 .c0:disabled {
@@ -738,7 +736,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: transparent;
+  background-color: rgba(16,173,82,0.01);
 }
 
 .c0:disabled {
@@ -770,8 +768,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
-  border-color: #E6F7EA;
+  background-color: rgba(230,247,234,0.01) border-color:#E6F7EA;
 }
 
 .c0:disabled {
@@ -1062,7 +1059,7 @@ exports[`Buttons Outline Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: transparent;
+  background-color: rgba(16,173,82,0.01);
 }
 
 .c0:disabled {
@@ -1351,7 +1348,7 @@ exports[`Buttons Outline Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: transparent;
+  background-color: rgba(16,173,82,0.01);
 }
 
 .c0:disabled {
@@ -1671,7 +1668,7 @@ exports[`Buttons Outline Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: transparent;
+  background-color: rgba(16,173,82,0.01);
 }
 
 .c0:disabled {

--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
+  background-color: transparent;
 }
 
 .c0:disabled {
@@ -388,7 +388,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
+  background-color: transparent;
 }
 
 .c0:disabled {
@@ -738,7 +738,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
+  background-color: transparent;
 }
 
 .c0:disabled {
@@ -1062,7 +1062,7 @@ exports[`Buttons Outline Button renders correctly 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
+  background-color: transparent;
 }
 
 .c0:disabled {
@@ -1351,7 +1351,7 @@ exports[`Buttons Outline Button renders correctly in disabled state 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
+  background-color: transparent;
 }
 
 .c0:disabled {
@@ -1671,7 +1671,7 @@ exports[`Buttons Outline Button renders correctly in loading state 1`] = `
 }
 
 .c0:focus {
-  background-color: #E6F7EA;
+  background-color: transparent;
 }
 
 .c0:disabled {

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -1,4 +1,5 @@
 import styled, { keyframes, css } from 'styled-components';
+import { makeOpaque } from '../../lib/color';
 
 const rotate360 = keyframes`
   from {
@@ -149,7 +150,7 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
     }
 
     &:focus {
-      background-color: transparent;
+      background-color: ${makeOpaque(theme.colors.green600, 0.01)}
     }
 
     &:disabled {
@@ -240,7 +241,7 @@ export const LinkButton = styled(OutlineButton)`
     }
 
     &:focus {
-      background-color: ${theme.colors.green50};
+      background-color: ${makeOpaque(theme.colors.green50, 0.01)}
       border-color: ${theme.colors.green50};
     }
 

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -150,7 +150,7 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
     }
 
     &:focus {
-      background-color: ${makeOpaque(theme.colors.green600, 0.01)}
+      background-color: ${makeOpaque(theme.colors.green600, 0.1)}
     }
 
     &:disabled {
@@ -241,7 +241,7 @@ export const LinkButton = styled(OutlineButton)`
     }
 
     &:focus {
-      background-color: ${makeOpaque(theme.colors.green50, 0.01)}
+      background-color: ${makeOpaque(theme.colors.green50, 0.1)}
       border-color: ${theme.colors.green50};
     }
 

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -149,7 +149,7 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
     }
 
     &:focus {
-      background-color: ${theme.colors.green50};
+      background-color: transparent;
     }
 
     &:disabled {

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -150,7 +150,7 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
     }
 
     &:focus {
-      background-color: ${makeOpaque(theme.colors.green600, 0.1)}
+      background-color: ${makeOpaque(theme.colors.green600, 0.1)};
     }
 
     &:disabled {
@@ -224,7 +224,7 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
 export const LinkButton = styled(OutlineButton)`
   ${({ theme }) => css`
     background: ${theme.colors.whiteDenim};
-    border-color: ${theme.colors.whiteDenim};
+    border: none;
     color: ${theme.colors.primary};
 
     i:before {
@@ -233,7 +233,6 @@ export const LinkButton = styled(OutlineButton)`
 
     &:hover {
       color: ${theme.colors.green900};
-      border-color: ${theme.colors.whiteDenim};
 
       i:before {
         color: ${theme.colors.green900};
@@ -241,13 +240,11 @@ export const LinkButton = styled(OutlineButton)`
     }
 
     &:focus {
-      background-color: ${makeOpaque(theme.colors.green50, 0.1)}
-      border-color: ${theme.colors.green50};
+      background-color: ${makeOpaque(theme.colors.green600, 0.1)};
     }
 
     &:disabled {
       background-color: ${theme.colors.whiteDenim};
-      border-color: ${theme.colors.whiteDenim};
     }
   `};
 `;

--- a/storybook/stories/Button.stories.tsx
+++ b/storybook/stories/Button.stories.tsx
@@ -36,13 +36,23 @@ storiesOf('Button', module)
   .add('Outline', () => (
     <>
       <h1>Outline Button</h1>
+      <Inversion>
+          <OutlineButton
+            onClick={action('Outline Button clicked')}
+            disabled={boolean('Disabled', false)}
+            loading={boolean('Loading', false)}
+            small={boolean('Small', false)}
+            >
+            {text('Label', 'Button')}
+          </OutlineButton>
+      </Inversion>
       <Container>
         <OutlineButton
           onClick={action('Outline Button clicked')}
           disabled={boolean('Disabled', false)}
           loading={boolean('Loading', false)}
           small={boolean('Small', false)}
-        >
+          >
           {text('Label', 'Button')}
         </OutlineButton>
       </Container>


### PR DESCRIPTION
The outline button is now transparent but the focus property was set to some sort of green color 👎 so I've changed the focus property to transparent and edited the storybook.


Before:
![Screen Shot 2019-11-21 at 1 30 41 PM](https://user-images.githubusercontent.com/39563306/69368671-8ecaaa00-0c68-11ea-88a3-c2022c131d20.png)

After: 
![Screen Shot 2019-11-21 at 2 09 13 PM](https://user-images.githubusercontent.com/39563306/69368672-8ecaaa00-0c68-11ea-9857-cc1202d3e1bc.png)

