### PR TITLE
Divider color prop

### DIFF
--- a/src/atoms/Divider/Divider.test.tsx
+++ b/src/atoms/Divider/Divider.test.tsx
@@ -24,9 +24,12 @@ describe('<Divider />', () => {
     expect(wrapper).toHaveStyleRule('margin', '8px 0');
   });
 
-  it('applies a custom color', () => {
-    const wrapper = mountWithTheme(<Divider color="#000" />);
+  it('applies a color', () => {
+    const wrapper = mountWithTheme(<Divider color="black" />);
 
-    expect(wrapper).toHaveStyleRule('border-top', '1px solid #000');
+    expect(wrapper).toHaveStyleRule(
+      'border-top',
+      `1px solid ${theme.colors.backToBlack}`
+    );
   });
 });

--- a/src/atoms/Divider/README.md
+++ b/src/atoms/Divider/README.md
@@ -13,8 +13,15 @@ After adding the import you can use the Divider simply like this
 ## Props
 Table below contains all types of props available in the Divider component
 
-| Name          | Type     | Default         | Description                      |
-| :------------ | :-----   | :-------------- | :------------------------------- |
-| space         | `Number` | `11`            | Customise the space before and after the divider
-| id            | `string` |                 | Default HTML id prop to identify the element
-| color         | `string` | `#F5F5F5`       | Custom color for the divider (hexcode)
+| Name          | Type          | Default         | Description                      |
+| :------------ | :-----        | :-------------- | :------------------------------- |
+| space         | `Number`      | `11`            | Customise the space before and after the divider
+| id            | `string`      |                 | Default HTML id prop to identify the element
+| color         | [Enum](#enum) | `#F5F5F5`       | Custom color for the divider
+
+### Enum
+| Color   | Description |
+| :------ | :---------- |
+| black   | #111111     |
+| white   | #FFFFFF     |
+| grey    | #DBDBDB     |

--- a/src/atoms/Divider/index.tsx
+++ b/src/atoms/Divider/index.tsx
@@ -1,14 +1,32 @@
 import styled, { css } from 'styled-components';
 
+type dividerColors = 'grey' | 'black' | 'white';
+
 interface DividerProps {
   space?: number;
-  color?: string;
+  color?: dividerColors;
 }
 
 export default styled.hr<DividerProps>`
   ${({ theme, space, color }) => css`
     border: none;
-    border-top: 1px solid ${color || theme.colors.silverSprings};
+    ${!color &&
+      css`
+        border-top: 1px solid ${theme.colors.silverSprings};
+      `}
+
+    ${color === 'white' &&
+      css`
+        border-top: 1px solid ${theme.colors.whiteDenim};
+      `}
+    ${color === 'black' &&
+      css`
+        border-top: 1px solid ${theme.colors.backToBlack};
+      `}
+    ${color === 'grey' &&
+      css`
+        border-top: 1px solid ${theme.colors.macyGrey};
+      `}
     width: 100%;
     margin: ${theme.ruler[space || 11]}px 0;
   `}

--- a/storybook/stories/Divider.stories.tsx
+++ b/storybook/stories/Divider.stories.tsx
@@ -19,7 +19,7 @@ storiesOf('Divider', module)
     <>
       <h1>Divider</h1>
       <Boundary>
-        <Divider color={text('Color', '#000')} />
+        <Divider color="black" />
       </Boundary>
     </>
   ));


### PR DESCRIPTION
## Description

Allow Divider component to take a `color` prop with three possible values: black, white and grey, which map to colors present on theme. Defaults to the current Divider color.