### PR TITLE
Fix Responsive component undefined window bug

### DIFF
--- a/src/atoms/Responsive/index.tsx
+++ b/src/atoms/Responsive/index.tsx
@@ -12,6 +12,8 @@ interface Props {
   showUp?: string;
 }
 
+const hasWindow = typeof window !== 'undefined';
+
 const findNext = (key: string): string | null => {
   const keys = Object.keys(breakPoints);
 
@@ -46,15 +48,19 @@ interface State {
 }
 export default class Responsive extends React.Component<Props, State> {
   public readonly state: State = {
-    windowSize: window.innerWidth
+    windowSize: hasWindow ? window.innerWidth : 0
   };
 
   public componentDidMount = () => {
-    window.addEventListener('resize', this.handleResize);
+    if (hasWindow) {
+      window.addEventListener('resize', this.handleResize);
+    }
   };
 
   public componentWillUnmount = () => {
-    window.removeEventListener('resize', this.handleResize);
+    if (hasWindow) {
+      window.removeEventListener('resize', this.handleResize);
+    }
   };
 
   private handleResize = () => {


### PR DESCRIPTION
## Description

The `Responsive` component uses `window` to grab the device window size and adds event listeners to it. On the server, `window` is not defined, so trying to render a page using the `Responsive` component throws a `ReferenceError: window is not defined` error. To avoid this we need to check if `window` is defined before accessing its width, adding event listeners.