### PR TITLE
Fix <Col> media query mapping

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+### Description
+<!--- Describe your changes in detail -->
+
+### Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+### How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+### Screenshots (if appropriate):
+
+### Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Improvement (non-breaking change which improves functionality or refactors code)
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+### Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/Grid/__snapshots__/Grid.test.tsx.snap
+++ b/src/atoms/Grid/__snapshots__/Grid.test.tsx.snap
@@ -291,13 +291,13 @@ exports[`Grid renders the Grid correctly 1`] = `
   grid-gap: 15px;
 }
 
-@media (min-width:768px) {
+@media (min-width:576px) {
   .c1 {
     grid-column-end: span 4;
   }
 }
 
-@media (min-width:992px) {
+@media (min-width:768px) {
   .c1 {
     grid-column-end: span 4;
   }

--- a/src/atoms/Grid/index.tsx
+++ b/src/atoms/Grid/index.tsx
@@ -19,12 +19,12 @@ export const Col = styled.div<ColProps>`
     grid-row: span ${rowSpan || 'auto'};
 
     ${sm &&
-      theme.media.md`
+      theme.media.sm`
       grid-column-end: span ${sm};
     `}
 
     ${md &&
-      theme.media.lg`
+      theme.media.md`
       grid-column-end: span ${md};
     `}
 


### PR DESCRIPTION
### Description

Currently when using the `<Grid>` component the developer has the option to define the breakpoints
for the different columns.
```
<Col xs={12} sm={6} md={4} lg={2}>Content...</Col>
```

However, the mapping for the props to the corresponding media queries was wrong. This PR fixes that

### How Has This Been Tested?
- Tested locally on storybook
- Updated unit tests / snapshot tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.