### PR TITLE
add shared-setup-exec back in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,14 @@
 version: 2.1
 
-jobs:
-  test:
+executors:
+  shared-setup-exec:
+    shell: /bin/bash --login
     docker:
       - image: circleci/node:11.12.0
+    working_directory: ~/repo
+jobs:
+  test:
+    executor: shared-setup-exec
     working_directory: ~/repo
     steps:
     - checkout
@@ -19,8 +24,7 @@ jobs:
     - run: yarn lint
     - run: yarn test
   deploy:
-    machine:
-      enabled: true
+    executor: shared-setup-exec
     steps:
     - checkout
     - run:


### PR DESCRIPTION
### Description

Change the circle config to re-use the shared executor