### PR TITLE
add an error & loading state to the Select

### DIFF
--- a/src/atoms/Icon/index.tsx
+++ b/src/atoms/Icon/index.tsx
@@ -58,6 +58,7 @@ interface IconProps {
   size?: string;
   color?: Colors;
   className?: string;
+  title?: string;
   'data-qaid'?: string;
   id?: string;
 }
@@ -65,6 +66,7 @@ const Icon: React.SFC<IconProps> = ({
   name,
   size,
   color,
+  title,
   className = '',
   'data-qaid': qaId,
   id
@@ -74,6 +76,7 @@ const Icon: React.SFC<IconProps> = ({
     className={`icon-${name} ${className}`}
     size={size}
     color={color}
+    title={title}
     data-qaid={qaId}
   />
 );

--- a/src/atoms/Spinner/README.md
+++ b/src/atoms/Spinner/README.md
@@ -1,0 +1,20 @@
+# Spinner
+
+To implement `Spinner` into your project you'll need to add this import
+```js
+import { Spinner } from '@sofarsounds/maestro'
+```
+
+After adding the import you can use it simply like this
+```html
+<Spinner />
+```
+
+## Props
+Table below contains all types of props available in the Spinner component
+
+| Name          | Type      | Default         | Description                      |
+| :------------ | :-----    | :-------------- | :------------------------------- |
+| size          | `string`  | `25px`          | The size of the spinner in pixels
+| invert        | `Boolean` | `false`         | Whether the invert the color of the spinner
+| data-qaid     | `string`  |                 | Optional prop for testing purposes

--- a/src/atoms/Spinner/index.tsx
+++ b/src/atoms/Spinner/index.tsx
@@ -1,0 +1,36 @@
+import styled, { css, keyframes } from '../../lib/styledComponents';
+
+const load8 = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+interface Props {
+  size?: string;
+  invert?: boolean;
+  'data-qaid'?: string;
+}
+
+export default styled.div<Props>`
+  ${({ theme, size = '25px', invert }) => css`
+    &:after {
+      border-radius: 50%;
+      width: 10em;
+      height: 10em;
+    }
+    position: relative;
+    border-top: 2px solid transparent;
+    border-right: 2px solid transparent;
+    border-bottom: 2px solid transparent;
+    border-left: 2px solid ${theme.colors[invert ? 'whiteDenim' : 'macyGrey']};
+    transform: translateZ(0);
+    animation: ${load8} 0.5s infinite linear;
+    border-radius: 50%;
+    width: ${size};
+    height: ${size};
+  `};
+`;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ export { default as Icons } from './atoms/Icon/registry';
 export { default as Textfield } from './atoms/Textfield';
 export { default as Textarea } from './atoms/Textarea';
 export { default as Spacer } from './atoms/Spacer';
+export { default as Spinner } from './atoms/Spinner';
 export { default as Radio } from './atoms/Radio';
 export { default as Checkbox } from './atoms/Checkbox';
 export { default as Responsive } from './atoms/Responsive';

--- a/src/molecules/Select/Input.test.tsx
+++ b/src/molecules/Select/Input.test.tsx
@@ -5,7 +5,7 @@ import Icon from '../../atoms/Icon';
 import Input from './Input';
 
 const setup = (props: any) =>
-  renderWithTheme(<Input data-qaid="test" {...props} />);
+  renderWithTheme(<Input data-qaid="test" state="ready" {...props} />);
 
 describe('<Select />', () => {
   describe('<Input />', () => {
@@ -79,6 +79,38 @@ describe('<Select />', () => {
         }
       });
 
+      expect(queryByTestId('test-clear')).not.toBeInTheDocument();
+    });
+
+    it('renders a loading spinner and no clear button when select state is loading', () => {
+      const mockClear = jest.fn();
+      const { queryByTestId } = setup({
+        state: 'loading',
+        inputProps: {
+          readOnly: false,
+          onChange: () => {},
+          onClear: mockClear,
+          value: ''
+        }
+      });
+
+      expect(queryByTestId('test-spinner')).toBeInTheDocument();
+      expect(queryByTestId('test-clear')).not.toBeInTheDocument();
+    });
+
+    it('renders an error icon and no clear button when select state is error', () => {
+      const mockClear = jest.fn();
+      const { queryByTestId } = setup({
+        state: 'error',
+        inputProps: {
+          readOnly: false,
+          onChange: () => {},
+          onClear: mockClear,
+          value: ''
+        }
+      });
+
+      expect(queryByTestId('test-error-icon')).toBeInTheDocument();
       expect(queryByTestId('test-clear')).not.toBeInTheDocument();
     });
 

--- a/src/molecules/Select/Input.tsx
+++ b/src/molecules/Select/Input.tsx
@@ -4,7 +4,9 @@ import styled, { css } from '../../lib/styledComponents';
 import { withTextfieldStyle, withShadow } from '../../util';
 import { InputProps } from '../../typings/input';
 
+import { SelectState } from './index';
 import Icon from '../../atoms/Icon';
+import Spinner from '../../atoms/Spinner';
 
 interface SelectInputProps {
   isOpen?: boolean;
@@ -27,6 +29,7 @@ interface Props {
   innerRef?: React.RefObject<HTMLInputElement>;
   hasError?: boolean;
   renderLeftIcon?: React.ReactNode;
+  state: SelectState;
   'data-qaid'?: string;
 
   inputProps: {
@@ -164,61 +167,84 @@ const Input: React.SFC<Props> = ({
   hasError,
   invertColor,
   renderLeftIcon,
+  state,
   'data-qaid': qaId
-}) => (
-  <Wrapper
-    id={inputProps.id}
-    readOnly={inputProps.readOnly}
-    hasError={hasError}
-    onClick={onToggle}
-    isOpen={isOpen}
-    ref={innerRef}
-    invertColor={invertColor}
-    data-qaid={qaId}
-  >
-    {renderLeftIcon && (
-      <IconWrapper invertColor={invertColor} data-qaid={`${qaId}-left-icon`}>
-        {renderLeftIcon}
-      </IconWrapper>
-    )}
+}) => {
+  const enableClearButton =
+    state === SelectState.ready &&
+    !inputProps.readOnly &&
+    inputProps.onClear &&
+    inputProps.value;
 
-    <StyledInput
-      value={inputProps.value}
+  return (
+    <Wrapper
+      id={inputProps.id}
       readOnly={inputProps.readOnly}
+      hasError={hasError}
+      onClick={onToggle}
       isOpen={isOpen}
-      placeholder={inputProps.placeholder || 'Please Select'}
-      name={inputProps.name}
-      onChange={inputProps.onChange}
+      ref={innerRef}
       invertColor={invertColor}
-      data-qaid={`${qaId}-input`}
-      autoComplete="nope"
-    />
+      data-qaid={qaId}
+    >
+      {renderLeftIcon && (
+        <IconWrapper invertColor={invertColor} data-qaid={`${qaId}-left-icon`}>
+          {renderLeftIcon}
+        </IconWrapper>
+      )}
 
-    {!inputProps.readOnly && inputProps.onClear && inputProps.value && (
+      <StyledInput
+        value={inputProps.value}
+        readOnly={inputProps.readOnly}
+        isOpen={isOpen}
+        placeholder={inputProps.placeholder || 'Please Select'}
+        name={inputProps.name}
+        onChange={inputProps.onChange}
+        invertColor={invertColor}
+        data-qaid={`${qaId}-input`}
+        autoComplete="nope"
+      />
+
+      {state === SelectState.loading && (
+        <div style={{ width: '30px' }}>
+          <Spinner data-qaid={`${qaId}-spinner`} size="20px" />
+        </div>
+      )}
+
+      {state === SelectState.error && (
+        <Icon
+          data-qaid={`${qaId}-error-icon`}
+          color="redRedWine"
+          name="alertTriangle"
+          title="Could not load options..."
+        />
+      )}
+
+      {enableClearButton && (
+        <ActionButton
+          invertColor={invertColor}
+          type="button"
+          data-qaid={`${qaId}-clear`}
+          onClick={inputProps.onClear}
+          title="Clear"
+        >
+          <Icon data-qaid={`${qaId}-clear-icon`} name="close" />
+        </ActionButton>
+      )}
+
       <ActionButton
         invertColor={invertColor}
+        isOpen={isOpen}
         type="button"
-        data-qaid={`${qaId}-clear`}
-        onClick={inputProps.onClear}
-        title="Clear"
+        data-qaid={`${qaId}-toggle`}
+        title="Toggle"
       >
-        <Icon data-qaid={`${qaId}-clear-icon`} name="close" />
+        <Icon
+          data-qaid={`${qaId}-toggle-icon`}
+          name={isOpen ? 'caretUp' : 'caretDown'}
+        />
       </ActionButton>
-    )}
-
-    <ActionButton
-      invertColor={invertColor}
-      isOpen={isOpen}
-      type="button"
-      data-qaid={`${qaId}-toggle`}
-      title="Toggle"
-    >
-      <Icon
-        data-qaid={`${qaId}-toggle-icon`}
-        name={isOpen ? 'caretUp' : 'caretDown'}
-      />
-    </ActionButton>
-  </Wrapper>
-);
-
+    </Wrapper>
+  );
+};
 export default Input;

--- a/src/molecules/Select/README.md
+++ b/src/molecules/Select/README.md
@@ -25,25 +25,34 @@ const cities = [
 
 ## Implements
 
-- [useDisableScroll](../../hooks/useDisableScroll)
-- [useOutsideClick](../../hooks/useOutsideClick)
-- [useKeyDown](../../hooks/useKeyDown)
+- [useSelect](../../hooks/useSelect)
 
 ## Select Props
 
 Table below contains all types of props available in the Select component  
 
-| Name                  | Type       | Default         | Description                      |
-| :------------         | :-----     | :-------------- | :------------------------------- |
-| **options**           | `Function` |                 | An array of options to render in the select
-| **placeholder**       | `string`   |                 | The placeholder/label to display before a value has been selected
-| getOptionValue        | `Function` | `id`            | If the option key is a different field than `id` you can override the default behaviour
-| getOptionLabel        | `Function` | `title`         | If the label you want to display is any other field than `title` you can override the default behaviour
-| renderOption          | `Function` |                 | Optional to render a custom option instead of the default one
-| renderLeftIcon        | `Function` |                 | Render an icon component on the left next to the label
-| handleOptionClick     | `Function` |                 | Optional funtion that's executed when selecting an option. Returns the options value
-| positionFixed         | `Boolean`  | `false`         | Set to true when the Select is positioned fixed on the screen. Otherwise the Menu will scroll away
-| disableScrollWhenOpen | `Boolean`  |                 | Disables body scroll when select is open
-| id                    | `string`   |                 | Default HTML id prop to identify the element
-| data-qaid             | `string`   |                 | Optional prop for testing purposes
+| Name                   | Type            | Default         | Description                      |
+| :------------          | :-----          | :-------------- | :------------------------------- |
+| **options**            | `Array`         |                 | An array of options to render in the select
+| **onChange**           | `Function`      |                 | Callback for when an option has been selected. Returns the entire option object
+| **placeholder**        | `string`        |                 | The placeholder/label to display before a value has been selected
+| **getOptionLabel**     | `Function`      |                 | Required to determine what to render as the label. Returns the current option object
+| defaultValue           | `Option / null` |                 | If a default value has been set, pass in the reference matching object in.
+| state                  | [Enum](#enum)   | `ready`         | The state of the select (ready, loading, or error)
+| searchable             | `Boolean`       |                 | Whether the select is searchable
+| renderOption           | `Function`      |                 | Optional to render a custom option instead of the default one
+| renderLeftIcon         | `Function`      |                 | Render an icon component on the left next to the label
+| popularOptions         | `Array`         |                 | A set of options that is displayed before the user starts filtering the list. Only works when `searchable` is `true`.
+| getPopularOptionsTitle | `Function`      |                 | Customise the title that is displayed for the group of popular options
+| groupBy                | `Function`      |                 | A custom group by function to create a grouped select.
+| disableScrollWhenOpen  | `Boolean`       |                 | Disables body scroll when select is open
+| id                     | `string`        |                 | Default HTML id prop to identify the element by id
+| name                   | `string`        |                 | Default HTML id prop to identify the element by name
+| data-qaid              | `string`        |                 | Optional prop for testing purposes
 
+### Enum
+| type     |
+| :------- |
+| ready    |
+| loading  |
+| error    |

--- a/src/molecules/Select/Select.test.tsx
+++ b/src/molecules/Select/Select.test.tsx
@@ -89,6 +89,26 @@ describe('<Select />', () => {
     expect(queryByTestId('select-menu')).not.toBeInTheDocument();
   });
 
+  it('renders correctly in the loading state', () => {
+    const { queryByTestId } = setup({
+      state: 'loading'
+    });
+
+    expect(queryByTestId('select-spinner')).toBeInTheDocument();
+    fireEvent.click(queryByTestId('select')!);
+    expect(queryByTestId('select-loading-msg')).toBeInTheDocument();
+  });
+
+  it('renders correctly in the error state', () => {
+    const { queryByTestId } = setup({
+      state: 'error'
+    });
+
+    expect(queryByTestId('select-error-icon')).toBeInTheDocument();
+    fireEvent.click(queryByTestId('select')!);
+    expect(queryByTestId('select-error-msg')).toBeInTheDocument();
+  });
+
   it('renders the correct options with the correct label', () => {
     const { queryByTestId, queryAllByTestId } = setup({
       getOptionLabel: (opt: any) => `${opt.title}, ${opt.country}`

--- a/src/molecules/Select/Typeahead.test.tsx
+++ b/src/molecules/Select/Typeahead.test.tsx
@@ -115,8 +115,10 @@ describe('<Typeahead />', () => {
     const input = queryByTestId('typeahead-input')!;
     fireEvent.change(input, { target: { value: 'I will not match' } });
 
-    expect(queryByTestId('typeahead-empty')).toBeInTheDocument();
-    expect(queryByTestId('typeahead-empty')).toHaveTextContent('No options...');
+    expect(queryByTestId('typeahead-empty-msg')).toBeInTheDocument();
+    expect(queryByTestId('typeahead-empty-msg')).toHaveTextContent(
+      'No options...'
+    );
   });
 
   it('selects an option and executes onChange after clicking a filtered option', () => {

--- a/src/molecules/Select/index.tsx
+++ b/src/molecules/Select/index.tsx
@@ -5,6 +5,12 @@ import { useSelect } from '../../hooks';
 import Input from './Input';
 import Options, { OptionsListProps } from './Options';
 
+export enum SelectState {
+  ready = 'ready',
+  loading = 'loading',
+  error = 'error'
+}
+
 export interface SelectProps<T> extends OptionsListProps<T> {
   // select props
   options: T[];
@@ -29,6 +35,7 @@ export interface SelectProps<T> extends OptionsListProps<T> {
   // misc props
   groupBy?: (option: T) => string;
   disableScrollWhenOpen?: boolean;
+  state?: SelectState;
   'data-qaid'?: string;
 }
 
@@ -48,6 +55,7 @@ const Select = <T extends {}>({
   renderLeftIcon,
   searchable = false,
   groupBy,
+  state = SelectState.ready,
   disableScrollWhenOpen = false,
   'data-qaid': qaId
 }: SelectProps<T>) => {
@@ -83,6 +91,7 @@ const Select = <T extends {}>({
         onToggle={() => onToggle(!isOpen)}
         renderLeftIcon={renderLeftIcon}
         hasError={hasError}
+        state={state}
         data-qaid={qaId}
       />
 
@@ -97,6 +106,7 @@ const Select = <T extends {}>({
         renderOption={renderOption}
         popularOptions={popularOptions}
         getPopularOptionsTitle={getPopularOptionsTitle}
+        state={state}
         userIsSearching={!!inputProps.value}
       />
     </>

--- a/storybook/stories/Select.stories.tsx
+++ b/storybook/stories/Select.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withKnobs, text, number, boolean } from '@storybook/addon-knobs';
 
-import { Icon, Select, MenuItem } from '../../src';
+import { Icon, Select, SelectState, MenuItem } from '../../src';
 
 import { cities, multiDimensional, MultiDimensional } from '../helpers/cities';
 import { Spacer, Boundary } from '../helpers/components';
@@ -58,6 +58,20 @@ const staticExamples = [
           <span style={{ color: '#ccc' }}>, {option.country}</span>
         </MenuItem>
       )
+    }
+  },
+  {
+    title: 'Loading',
+    props: {
+      ...defaultProps,
+      state: SelectState.loading
+    }
+  },
+  {
+    title: 'Error',
+    props: {
+      ...defaultProps,
+      state: SelectState.error
     }
   }
 ];

--- a/storybook/stories/Spinner.stories.tsx
+++ b/storybook/stories/Spinner.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+
+import { Spinner } from '../../src';
+import { Boundary } from '../helpers/components';
+
+storiesOf('Spinner', module)
+  .addDecorator(withKnobs)
+  .add('Default', () => {
+    const invert = boolean('Invert', false);
+    const size = text('Size', '25px');
+
+    return (
+      <>
+        <h1>Spinner</h1>
+        <Boundary
+          style={{
+            display: 'inline-block',
+            background: invert ? '#000' : '#fff',
+            padding: '20px'
+          }}
+        >
+          <Spinner invert={invert} size={size} />
+        </Boundary>
+      </>
+    );
+  });


### PR DESCRIPTION
### Description

The `Select` component needs to be able to handle a `loading` and `error` state to indicate to the user what's happening. This is especially important for Selects which fetch data from an api.

- Add `state` prop which can be set to `ready`, `loading` or `error` (defaults to `ready`)
- Add `Spinner` atom component
- Display `Spinner` when loading
- Display error icon when error occurred
- Update `Select` Readme

### How Has This Been Tested?
- Locally in storybook
- By writing new tests

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

