### PR TITLE
Re-order Navbar items in mobile view

### DIFF
--- a/src/molecules/Navbar/Collapsible.tsx
+++ b/src/molecules/Navbar/Collapsible.tsx
@@ -11,8 +11,8 @@ export default styled.div<WrapperProps>`
     ${open &&
       css`
         display: flex;
-        flex-direction: column-reverse;
-        justify-content: flex-end;
+        flex-direction: column;
+        justify-content: flex-start;
         position: fixed;
         top: ${theme.dimensions.navbarHeight.xs};
         left: 0;
@@ -20,7 +20,7 @@ export default styled.div<WrapperProps>`
         bottom: 0;
         background: #000;
         border-top: 1px solid ${theme.colors.paintItBlack};
-        padding: 0 15px;
+        padding: ${theme.ruler[4]}px;
       `}
 
     ${theme.media.md`

--- a/src/molecules/Navbar/NavbarContainer.tsx
+++ b/src/molecules/Navbar/NavbarContainer.tsx
@@ -17,24 +17,25 @@ export default styled.div<NavbarContainerProps>`
     align-items: center;
     justify-content: center;
     z-index: ${theme.zIndex.navbar};
-      ${position === 'absolute' &&
-        css`
-          position: absolute;
-        `}
-      ${position === 'fixed' &&
-        css`
-          position: fixed;
-          top: 0;
-          left: 0;
-          right: 0;
-        `}
-      ${transparent &&
-        theme.media.md`
+    ${position === 'absolute' &&
+      css`
+        position: absolute;
+      `};
+    ${position === 'fixed' &&
+      css`
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+      `};
+    ${transparent &&
+      theme.media.md`
         background: transparent;
-      `}
-      ${theme.media.md`
+      `};
+    ${theme.media.md`
       height: ${theme.dimensions.navbarHeight.md};
-    `} ${theme.media.lg`
+    `};
+    ${theme.media.lg`
       height: ${theme.dimensions.navbarHeight.lg};
     `};
   `}

--- a/storybook/stories/Header.stories.tsx
+++ b/storybook/stories/Header.stories.tsx
@@ -14,7 +14,7 @@ import {
   Menu,
   OutlineButton
 } from '../../src';
-import { cities } from '../helpers/cities';
+import { cities, MultiDimensional, multiDimensional } from '../helpers/cities';
 
 storiesOf('Header', module)
   .addDecorator(withKnobs)
@@ -23,30 +23,13 @@ storiesOf('Header', module)
       <div>
         <Navbar data-qaid="navbar">
           <Navbar.ItemContainer>
-            <Dropdown
-              flyoutContainer={false}
-              offset={{ vertical: -2 }}
-              renderLabel={isOpen => (
-                <OutlineButton small color={'white'}>
-                  <span style={{ marginRight: '5px', color: 'inherit' }}>
-                    Cities
-                  </span>
-                  <Icon
-                    color={'whiteDenim'}
-                    name={isOpen ? 'caretUp' : 'caretDown'}
-                    size={'8px'}
-                  />
-                </OutlineButton>
-              )}
-            >
-              <Menu width={'150px'}>
-                {cities.map((city, index) => (
-                  <MenuItem key={index} onClick={action('I was clicked')}>
-                    {city}
-                  </MenuItem>
-                ))}
-              </Menu>
-            </Dropdown>
+            <Select<MultiDimensional>
+              invertColor
+              options={multiDimensional}
+              getOptionLabel={o => o.title}
+              placeholder="Select City"
+              onChange={o => console.log(o)}
+            />
           </Navbar.ItemContainer>
 
           <Navbar.ItemContainer align="right">


### PR DESCRIPTION
### Description

The `<Navbar />` has a left and right section. Currently, when opening the navigation on mobile devices, the left section will be rendered at the bottom. We have made the decision to flip that around and render it at the top.

### How Has This Been Tested?
- In storybook

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

