### PR TITLE
Fix issue with Popper when no width is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/Popper/index.tsx
+++ b/src/atoms/Popper/index.tsx
@@ -118,7 +118,7 @@ const Popper: React.SFC<Props> = ({
     updateCalculatedPosition(anchorEl);
   });
 
-  const { y, x, width: anchorElWidth, contactPoint } = calculatedPosition;
+  const { y, x, contactPoint } = calculatedPosition;
 
   return (
     <Container
@@ -126,7 +126,7 @@ const Popper: React.SFC<Props> = ({
       style={{
         top: `${y}px`,
         left: `${x}px`,
-        width: width === 'auto' ? anchorElWidth : width
+        width: width === 'auto' ? 'undefined' : width
       }}
     >
       {typeof children === 'function' ? children({ contactPoint }) : children}


### PR DESCRIPTION
### Description

Fixes an issue where the Popper component horizontal transform origin didn't work correctly
if no width was passed in manually.

### How Has This Been Tested?
- In storybook

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.