### PR TITLE
Allow Cols to start at defined points in the grid

### DIFF
--- a/src/atoms/Grid/Grid.test.tsx
+++ b/src/atoms/Grid/Grid.test.tsx
@@ -29,4 +29,28 @@ describe('Grid', () => {
 
     expect(grid).toMatchSnapshot();
   });
+
+  it('renders a grid with custom start points', () => {
+    const grid = mountWithTheme(
+      <Grid>
+        <Col
+          xs={6}
+          sm={6}
+          md={6}
+          lg={6}
+          xsStart={4}
+          mdStart={4}
+          smStart={4}
+          lgStart={4}
+        >
+          Col 1 / Row 1
+        </Col>
+        <Col xs={6} sm={6} md={6} lg={6}>
+          Col 1 / Row 2
+        </Col>
+      </Grid>
+    );
+
+    expect(grid).toMatchSnapshot();
+  });
 });

--- a/src/atoms/Grid/README.md
+++ b/src/atoms/Grid/README.md
@@ -16,6 +16,18 @@ After adding the import you can use the Grid simply like this
 </Grid>
 ```
 
+If you'd like a column to start further across the x axis you can use:
+```html
+<Grid>
+  <Col xs={12} sm={5}>
+    A column
+  </Col>
+  <Col xs={12} sm={6} xmStart={7}>
+    A second column
+  </Col>
+</Grid>
+```
+
 If you'd like to add a row height to a column that use the `rowSpan` attribute,
 which uses css-grid's `grid-row` attribute.
 
@@ -50,6 +62,11 @@ which uses css-grid's `grid-row` attribute.
 | md            | `number`     |                 | Number of columns taken up on `md` devices
 | lg            | `number`     |                 | Number of columns taken up on `lg` devices
 | xl            | `number`     |                 | Number of columns taken up on `xl` devices
+| xsStart       | `number`     | auto            | Column No on X axis to start col on `xs` devices
+| smStart       | `number`     | auto            | Column No on X axis to start col on `sm` devices
+| mdStart       | `number`     | auto            | Column No on X axis to start col on `md` devices
+| lgStart       | `number`     | auto            | Column No on X axis to start col on `lg` devices
+| xlStart       | `number`     | auto            | Column No on X axis to start col on `xl` devices
 | data-qaid     | `string`     |                 | Optional prop for testing purposes
 | id            | `string`     |                 | Default HTML id prop to identify the element
 | rowSpan       | `number`     | 'auto'          | Number of rows taken up on all size screens

--- a/src/atoms/Grid/__snapshots__/Grid.test.tsx.snap
+++ b/src/atoms/Grid/__snapshots__/Grid.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Grid renders a Grid with a custom gap 1`] = `
 .c1 {
   grid-column-end: span 12;
+  grid-column-start: auto;
   grid-row: span auto;
 }
 
@@ -278,9 +279,16 @@ exports[`Grid renders a Grid with a custom gap 1`] = `
 </ThemeProvider>
 `;
 
-exports[`Grid renders the Grid correctly 1`] = `
+exports[`Grid renders a grid with custom start points 1`] = `
 .c1 {
-  grid-column-end: span 12;
+  grid-column-end: span 6;
+  grid-column-start: 4;
+  grid-row: span auto;
+}
+
+.c2 {
+  grid-column-end: span 6;
+  grid-column-start: auto;
   grid-row: span auto;
 }
 
@@ -293,18 +301,365 @@ exports[`Grid renders the Grid correctly 1`] = `
 
 @media (min-width:576px) {
   .c1 {
+    grid-column-start: 4;
+    grid-column-end: span 6;
+  }
+}
+
+@media (min-width:768px) {
+  .c1 {
+    grid-column-start: 4;
+    grid-column-end: span 6;
+  }
+}
+
+@media (min-width:992px) {
+  .c1 {
+    grid-column-start: 4;
+    grid-column-end: span 6;
+  }
+}
+
+@media (min-width:576px) {
+  .c2 {
+    grid-column-start: auto;
+    grid-column-end: span 6;
+  }
+}
+
+@media (min-width:768px) {
+  .c2 {
+    grid-column-start: auto;
+    grid-column-end: span 6;
+  }
+}
+
+@media (min-width:992px) {
+  .c2 {
+    grid-column-start: auto;
+    grid-column-end: span 6;
+  }
+}
+
+@media (min-width:576px) {
+  .c0 {
+    grid-gap: 30px;
+  }
+}
+
+<ThemeProvider
+  theme={
+    Object {
+      "borderRadius": Object {
+        "button": "4px",
+        "default": "2px",
+        "input": "2px",
+        "large": "8px",
+      },
+      "colors": Object {
+        "backToBlack": "#111111",
+        "black": "#000000",
+        "blackBetty": "#1E1E1E",
+        "blueSmoke": "#949494",
+        "green100": "#CFEACC",
+        "green200": "#9DDCAC",
+        "green300": "#72D08A",
+        "green400": "#4FC571",
+        "green50": "#E6F7EA",
+        "green500": "#23BA57",
+        "green600": "#10AD52",
+        "green700": "#039842",
+        "green800": "#008736",
+        "green900": "#006721",
+        "macyGrey": "#DBDBDB",
+        "paintItBlack": "#333333",
+        "primary": "#039842",
+        "redRedWine": "#EF4423",
+        "silverSprings": "#F5F5F5",
+        "whiteDenim": "#FFFFFF",
+      },
+      "dimensions": Object {
+        "button": Object {
+          "default": Object {
+            "height": "44px",
+            "padding": "0 25px",
+          },
+          "small": Object {
+            "height": "40px",
+            "padding": "0 15px",
+          },
+        },
+        "buttonHeight": "44px",
+        "containerWidth": Object {
+          "default": "800px",
+          "fullscreen": "100%",
+          "large": "1000px",
+          "small": "600px",
+        },
+        "inputHeight": "44px",
+        "navbarHeight": Object {
+          "lg": "84px",
+          "md": "74px",
+          "xs": "62px",
+        },
+        "radioBox": "20px",
+      },
+      "fontSizes": Object {
+        "base": "16px",
+        "body1": "16px",
+        "body2": "14px",
+        "button": "14px",
+        "caption": "10px",
+        "formGroupLabel": "14px",
+        "h1": Object {
+          "lg": "48px",
+          "md": "34px",
+          "xs": "24px",
+        },
+        "h2": Object {
+          "lg": "34px",
+          "md": "24px",
+          "xs": "20px",
+        },
+        "h3": Object {
+          "lg": "24px",
+          "md": "20px",
+          "xs": "16px",
+        },
+        "h4": Object {
+          "lg": "20px",
+          "md": "16px",
+          "xs": "16px",
+        },
+        "h5": Object {
+          "lg": "16px",
+          "md": "14px",
+          "xs": "14px",
+        },
+        "h6": Object {
+          "lg": "14px",
+          "md": "14px",
+          "xs": "14px",
+        },
+        "overline": "10px",
+        "title": Object {
+          "lg": "54px",
+          "md": "38px",
+          "xs": "26px",
+        },
+      },
+      "fonts": Object {
+        "regular": "Open Sans",
+      },
+      "media": Object {
+        "lg": [Function],
+        "md": [Function],
+        "sm": [Function],
+        "xl": [Function],
+        "xs": [Function],
+      },
+      "ruler": Array [
+        0,
+        4,
+        8,
+        12,
+        16,
+        20,
+        24,
+        28,
+        32,
+        36,
+        40,
+        44,
+        48,
+        52,
+        56,
+        60,
+        64,
+        68,
+        72,
+        76,
+        80,
+      ],
+      "utils": Object {
+        "transition": [Function],
+      },
+      "zIndex": Object {
+        "navbar": 100,
+      },
+    }
+  }
+>
+  <styled.div>
+    <StyledComponent
+      forwardedComponent={
+        Object {
+          "$$typeof": Symbol(react.forward_ref),
+          "attrs": Array [],
+          "componentStyle": ComponentStyle {
+            "componentId": "sc-bwzfXH",
+            "isStatic": false,
+            "lastClassName": "c0",
+            "rules": Array [
+              "
+  ",
+              [Function],
+              "
+",
+            ],
+          },
+          "displayName": "styled.div",
+          "foldedComponentIds": Array [],
+          "render": [Function],
+          "styledComponentId": "sc-bwzfXH",
+          "target": "div",
+          "toString": [Function],
+          "warnTooManyClasses": [Function],
+          "withComponent": [Function],
+        }
+      }
+      forwardedRef={null}
+    >
+      <div
+        className="c0"
+      >
+        <styled.div
+          lg={6}
+          lgStart={4}
+          md={6}
+          mdStart={4}
+          sm={6}
+          smStart={4}
+          xs={6}
+          xsStart={4}
+        >
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-bdVaJa",
+                  "isStatic": false,
+                  "lastClassName": "c2",
+                  "rules": Array [
+                    "
+  ",
+                    [Function],
+                    "
+",
+                  ],
+                },
+                "displayName": "styled.div",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-bdVaJa",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            lg={6}
+            lgStart={4}
+            md={6}
+            mdStart={4}
+            sm={6}
+            smStart={4}
+            xs={6}
+            xsStart={4}
+          >
+            <div
+              className="c1"
+            >
+              Col 1 / Row 1
+            </div>
+          </StyledComponent>
+        </styled.div>
+        <styled.div
+          lg={6}
+          md={6}
+          sm={6}
+          xs={6}
+        >
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "sc-bdVaJa",
+                  "isStatic": false,
+                  "lastClassName": "c2",
+                  "rules": Array [
+                    "
+  ",
+                    [Function],
+                    "
+",
+                  ],
+                },
+                "displayName": "styled.div",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "sc-bdVaJa",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+            lg={6}
+            md={6}
+            sm={6}
+            xs={6}
+          >
+            <div
+              className="c2"
+            >
+              Col 1 / Row 2
+            </div>
+          </StyledComponent>
+        </styled.div>
+      </div>
+    </StyledComponent>
+  </styled.div>
+</ThemeProvider>
+`;
+
+exports[`Grid renders the Grid correctly 1`] = `
+.c1 {
+  grid-column-end: span 12;
+  grid-column-start: auto;
+  grid-row: span auto;
+}
+
+.c0 {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(12,1fr);
+  grid-gap: 15px;
+}
+
+@media (min-width:576px) {
+  .c1 {
+    grid-column-start: auto;
     grid-column-end: span 4;
   }
 }
 
 @media (min-width:768px) {
   .c1 {
+    grid-column-start: auto;
     grid-column-end: span 4;
   }
 }
 
 @media (min-width:992px) {
   .c1 {
+    grid-column-start: auto;
     grid-column-end: span 4;
   }
 }

--- a/src/atoms/Grid/index.tsx
+++ b/src/atoms/Grid/index.tsx
@@ -11,30 +11,53 @@ interface ColProps {
   md?: number;
   lg?: number;
   xl?: number;
+  xsStart?: number;
+  smStart?: number;
+  mdStart?: number;
+  lgStart?: number;
+  xlStart?: number;
   rowSpan?: number;
 }
 export const Col = styled.div<ColProps>`
-  ${({ theme, xs, sm, md, lg, xl, rowSpan }) => css`
+  ${({
+    theme,
+    xs,
+    sm,
+    md,
+    lg,
+    xl,
+    xsStart,
+    smStart,
+    mdStart,
+    lgStart,
+    xlStart,
+    rowSpan
+  }) => css`
     grid-column-end: span ${xs || 12};
+    grid-column-start: ${xsStart || 'auto'};
     grid-row: span ${rowSpan || 'auto'};
 
     ${sm &&
       theme.media.sm`
+      grid-column-start: ${smStart || 'auto'};
       grid-column-end: span ${sm};
     `}
 
     ${md &&
       theme.media.md`
+      grid-column-start: ${mdStart || 'auto'};
       grid-column-end: span ${md};
     `}
 
     ${lg &&
       theme.media.lg`
+      grid-column-start: ${lgStart || 'auto'};
       grid-column-end: span ${lg};
     `}
 
     ${xl &&
       theme.media.xl`
+      grid-column-start: ${xlStart || 'auto'};
       grid-column-end: span ${xl};
     `}
   `}

--- a/storybook/stories/Grid.stories.tsx
+++ b/storybook/stories/Grid.stories.tsx
@@ -66,6 +66,19 @@ storiesOf('Grid', module)
 
       <Space />
 
+      <h2>Customise Grid column layout</h2>
+      <Grid gap="5px">
+        <Col sm={6} smStart={4}>
+          <ColContent>Row 1 / Column 1</ColContent>
+        </Col>
+        <Col sm={6}>
+          <ColContent>Row 2 / Column 1</ColContent>
+        </Col>
+        <Col sm={6}>
+          <ColContent>Row 2 / Column 2</ColContent>
+        </Col>
+      </Grid>
+
       <h2>Row Span</h2>
       <Grid>
         <Col xs={12} sm={6} rowSpan={2}>


### PR DESCRIPTION


Adds props to allow us to define where in the grid a column starts

### Description
Rather than using auto so that all cols flow after each other we can
pass in additional props to define the starting point on that row.

These props set grid-column-start if not defined it is backwards
compatible and sets it as auto.

### Motivation and Context
We have designs where not all columns follow in the next available
column. With the current grid we can not achieve that using this component
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
Unit test (via snapshot) and storybook testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):
<img width="1176" alt="Screenshot 2020-08-19 at 21 03 22" src="https://user-images.githubusercontent.com/345801/90684573-59d39e00-e260-11ea-8206-4d369de2624a.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


