### PR TITLE
allow showOnSizes array param on Responsive wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.3.6",
+  "version": "7.3.7",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/Responsive/README.md
+++ b/src/atoms/Responsive/README.md
@@ -17,13 +17,14 @@ After adding the import you can use it simply like this
 
 Table below contains all types of props available in the Logo component  
 
-| Name          | Type          | Default         | Description                      |
-| :------------ | :-----        | :-------------- | :------------------------------- |
-| **children**  | `React.Node`  |                 | The content to display or hide
-| hide          | [Enum](#enum) |                 | Hide given content on *exact* screen size only
-| show          | [Enum](#enum) |                 | Show given content on *exact* screen size only
-| hideUp        | [Enum](#enum) |                 | Hide given content on given screen size and up
-| showUp        | [Enum](#enum) |                 | Show given content on given screen size and up
+| Name          | Type            | Default         | Description                      |
+| :------------ | :-----          | :-------------- | :------------------------------- |
+| **children**  | `React.Node`    |                 | The content to display or hide
+| showOnSizes   | [Enum[]](#enum) |                 | Show given content on an array of screen sizes
+| hide          | [Enum](#enum)   |                 | Hide given content on *exact* screen size only
+| show          | [Enum](#enum)   |                 | Show given content on *exact* screen size only
+| hideUp        | [Enum](#enum)   |                 | Hide given content on given screen size and up
+| showUp        | [Enum](#enum)   |                 | Show given content on given screen size and up
 
 ### Enum
 

--- a/src/atoms/Responsive/index.tsx
+++ b/src/atoms/Responsive/index.tsx
@@ -10,6 +10,8 @@ interface Props {
 
   hideUp?: string;
   showUp?: string;
+
+  showOnSizes?: string[];
 }
 
 const hasWindow = typeof window !== 'undefined';
@@ -68,8 +70,15 @@ export default class Responsive extends React.Component<Props, State> {
   };
 
   public render() {
-    const { hide, hideUp, show, showUp, children } = this.props;
+    const { hide, hideUp, show, showUp, showOnSizes, children } = this.props;
     const { windowSize } = this.state;
+
+    if (showOnSizes) {
+      const inAnyBoundary = showOnSizes
+        .map((size: string) => isInBoundary(size, windowSize, false))
+        .reduce((a, b) => a || b);
+      return !inAnyBoundary ? null : children;
+    }
 
     if (hide || hideUp) {
       const useHideProp = hide || hideUp;

--- a/storybook/stories/Responsive.stories.tsx
+++ b/storybook/stories/Responsive.stories.tsx
@@ -78,5 +78,15 @@ storiesOf('Responsive', module).add('Basic', () => (
         </Responsive>
       </Example>
     ))}
+
+    <Spacer />
+
+    <h2>Show on array of exact screen sizes</h2>
+    <Example>
+      Only visible on [md, xl] devices:
+      <Responsive showOnSizes={["md", "xl"]}>
+        <Box>I am visible only on [md, xl] devices</Box>
+      </Responsive>
+    </Example>
   </div>
 ));


### PR DESCRIPTION
### Description/Motivation/Context
This adds a `showOnSizes` parameter to the `<Responsive>` atom, so that we can accomplish more complex responsive behavior needed for the Artist DB (for the dividers between rows of artist cards) than is currently possible with the `<Responsive>` atom, since it only has `showUp`, `hideUp`, `show`, and `hide` parameters. The `showOnSizes` param will let you simply have an element show on medium and XL screens but not large screens, for example.

### How Has This Been Tested?
View the new storybook test that was added to the Responsive section of storybook.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

