### PR TITLE
Add size guide storybook for easy lookup

### DIFF
--- a/storybook/stories/Typography.stories.tsx
+++ b/storybook/stories/Typography.stories.tsx
@@ -16,13 +16,30 @@ import {
   Body2,
   Overline,
   Anchor,
-  Caption
+  Caption,
+  theme
 } from '../../src';
 
 import { Boundary as Bound } from '../helpers/components';
 
 const Boundary = styled(Bound)`
   margin-bottom: 25px;
+`;
+
+export const DataTable = styled.table`
+  border-collapse: collapse;
+`;
+
+export const TH = styled.th`
+  border-bottom: 2px SOLID #cccccc;
+  min-width: 150px;
+  text-align: left;
+  padding: 4px;
+`;
+
+export const TD = styled.td`
+  border-bottom: 1px SOLID #cccccc;
+  padding: 4px;
 `;
 
 const headingTags = [H1, H2, H3, H4, H5, H6];
@@ -37,6 +54,86 @@ storiesOf('Typography', module)
       url: 'https://www.figma.com/file/P31na2HYB09sF7v5B0nqkJ/Sofar-Design-System?node-id=6%3A2',
     },
   })
+  .add('Size Guide', () => (
+    <DataTable>
+      <thead>
+        <tr>
+          <TH>Type</TH>
+          <TH>Large</TH>
+          <TH>Medium</TH>
+          <TH>Small & Xtra Small</TH>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <TD>Title</TD>
+          <TD>{theme.fontSizes.title.lg}</TD>
+          <TD>{theme.fontSizes.title.md}</TD>
+          <TD>{theme.fontSizes.title.xs}</TD>
+        </tr>
+        <tr>
+          <TD>H1</TD>
+          <TD>{theme.fontSizes.h1.lg}</TD>
+          <TD>{theme.fontSizes.h1.md}</TD>
+          <TD>{theme.fontSizes.h1.xs}</TD>
+        </tr>
+        <tr>
+          <TD>H2</TD>
+          <TD>{theme.fontSizes.h2.lg}</TD>
+          <TD>{theme.fontSizes.h2.md}</TD>
+          <TD>{theme.fontSizes.h2.xs}</TD>
+        </tr>
+        <tr>
+          <TD>H3</TD>
+          <TD>{theme.fontSizes.h3.lg}</TD>
+          <TD>{theme.fontSizes.h3.md}</TD>
+          <TD>{theme.fontSizes.h3.xs}</TD>
+        </tr>
+        <tr>
+          <TD>H4</TD>
+          <TD>{theme.fontSizes.h4.lg}</TD>
+          <TD>{theme.fontSizes.h4.md}</TD>
+          <TD>{theme.fontSizes.h4.xs}</TD>
+        </tr>
+        <tr>
+          <TD>H5</TD>
+          <TD>{theme.fontSizes.h5.lg}</TD>
+          <TD>{theme.fontSizes.h5.md}</TD>
+          <TD>{theme.fontSizes.h5.xs}</TD>
+        </tr>
+        <tr>
+          <TD>H6</TD>
+          <TD>{theme.fontSizes.h6.lg}</TD>
+          <TD>{theme.fontSizes.h6.md}</TD>
+          <TD>{theme.fontSizes.h6.xs}</TD>
+        </tr>
+        <tr>
+          <TD>Body1</TD>
+          <TD>{theme.fontSizes.body1}</TD>
+          <TD>{theme.fontSizes.body1}</TD>
+          <TD>{theme.fontSizes.body1}</TD>
+        </tr>
+        <tr>
+          <TD>Body2</TD>
+          <TD>{theme.fontSizes.body2}</TD>
+          <TD>{theme.fontSizes.body2}</TD>
+          <TD>{theme.fontSizes.body2}</TD>
+        </tr>
+        <tr>
+          <TD>Overline</TD>
+          <TD>{theme.fontSizes.overline}</TD>
+          <TD>{theme.fontSizes.overline}</TD>
+          <TD>{theme.fontSizes.overline}</TD>
+        </tr>
+        <tr>
+          <TD>Caption</TD>
+          <TD>{theme.fontSizes.caption}</TD>
+          <TD>{theme.fontSizes.caption}</TD>
+          <TD>{theme.fontSizes.caption}</TD>
+        </tr>
+      </tbody>
+    </DataTable>
+  ))
   .add('Title', () => (
     <>
       <h1>Titles</h1>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
Adds a new story which displays typographical componets font size.

### Motivation and Context
To allow easier lookup of current font size for typographical components
provide a table of components and size across responsive layouts.  These
are taken from our theme so should get updated in realtime

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):
![Screenshot 2020-10-02 at 13 45 51](https://user-images.githubusercontent.com/345801/94924847-2cf8e480-04b6-11eb-8de0-809515f9afed.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

