### PR TITLE
Fix focusability issues on Select component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.3.8",
+  "version": "7.3.9",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -206,7 +206,8 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
         }
 
         &:focus {
-          background-color: ${theme.colors.backToBlack};
+          border-color: ${theme.colors.silverSprings};
+          background: rgba(219, 219, 219, 0.1); //macyGrey at 10%
         }
       `}
 

--- a/src/molecules/Select/Input.tsx
+++ b/src/molecules/Select/Input.tsx
@@ -38,7 +38,6 @@ interface Props {
     id?: string;
     placeholder?: string;
     readOnly?: boolean;
-
     name?: string;
     value?: string;
     onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/molecules/Select/Input.tsx
+++ b/src/molecules/Select/Input.tsx
@@ -33,7 +33,6 @@ interface Props {
   state: SelectState;
   initialWidth?: string;
   'data-qaid'?: string;
-  tabIndex?: string;
 
   inputProps: {
     id?: string;

--- a/src/molecules/Select/Input.tsx
+++ b/src/molecules/Select/Input.tsx
@@ -33,11 +33,13 @@ interface Props {
   state: SelectState;
   initialWidth?: string;
   'data-qaid'?: string;
+  tabIndex?: string;
 
   inputProps: {
     id?: string;
     placeholder?: string;
     readOnly?: boolean;
+
     name?: string;
     value?: string;
     onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -80,6 +82,10 @@ const Wrapper = styled.div<Wrapper>`
 
         &:hover {
           border-color: ${theme.colors.whiteDenim};
+        }
+        &:focus {
+          border-color: ${theme.colors.silverSprings};
+          background: rgba(219, 219, 219, 0.1); //macyGrey at 10%
         }
       `}
 
@@ -200,6 +206,7 @@ const Input: React.SFC<Props> = ({
     <Wrapper
       id={inputProps.id}
       readOnly={inputProps.readOnly}
+      tabIndex={0}
       hasError={hasError}
       onClick={onToggle}
       isOpen={isOpen}

--- a/src/molecules/Select/index.tsx
+++ b/src/molecules/Select/index.tsx
@@ -24,7 +24,6 @@ export interface SelectProps<T> extends OptionsListProps<T> {
   hasError?: boolean;
   invertColor?: boolean;
   renderLeftIcon?: React.ReactNode;
-  tabIndex?: string;
 
   // typeahead props
   searchable?: boolean;

--- a/src/molecules/Select/index.tsx
+++ b/src/molecules/Select/index.tsx
@@ -24,6 +24,7 @@ export interface SelectProps<T> extends OptionsListProps<T> {
   hasError?: boolean;
   invertColor?: boolean;
   renderLeftIcon?: React.ReactNode;
+  tabIndex?: string;
 
   // typeahead props
   searchable?: boolean;


### PR DESCRIPTION
1. Added focusability to wrapped div of the Select component
2. updated focus state on inverted color theme for button and select

### Motivation and Context

Since we've had to build the "select" component using a div (instead of a select html element) for the functionality we need, it's not currently keyboard accessible. This change makes the select component visibly focasable on tab. 

### How Has This Been Tested?
Only visually tested in storybook. Let me know if this should have a test written for it. 

### Screenshots (if appropriate):
<img width="640" alt="Screen Shot 2020-10-20 at 2 26 37 PM" src="https://user-images.githubusercontent.com/3356406/96632505-d24cee80-12e5-11eb-9878-8706d9b2edce.png">
<img width="656" alt="Screen Shot 2020-10-20 at 2 27 05 PM" src="https://user-images.githubusercontent.com/3356406/96632506-d2e58500-12e5-11eb-9325-5cff0459589c.png">


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project. (At least, I think so🤞)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

