### PR TITLE
allow useModal hook to have an initial isShowing state

### DIFF
--- a/src/hooks/useModal/index.tsx
+++ b/src/hooks/useModal/index.tsx
@@ -5,8 +5,10 @@ export interface UseModalProps {
   hide: () => void;
 }
 
-const useModal = (): [UseModalProps, () => void] => {
-  const [isShowing, setIsShowing] = useState(false);
+const useModal = (
+  initialToggleState?: boolean
+): [UseModalProps, () => void] => {
+  const [isShowing, setIsShowing] = useState(initialToggleState || false);
 
   function toggle() {
     setIsShowing(!isShowing);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context

Our `useModal` hook always defaults its `isShowing` state to `false`. On some of our new pages such as ArtistDB the page should load with the modal already open, and we've accomplished that through a `useEffect` callback. This isn't ideal since the user can visibly see state changing as the page loads, so it would be better if we could set the initial value of the `useModal` hook's `isShowing` state.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

