### PR TITLE
fix Outline button disabled state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.3.17",
+  "version": "7.3.18",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c2:disabled {
-  background-color: #FFFFFF;
+  background-color: transparent;
   color: #949494;
 }
 
@@ -361,7 +361,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #FFFFFF;
+  background-color: transparent;
   color: #949494;
 }
 
@@ -677,7 +677,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #FFFFFF;
+  background-color: transparent;
   color: #949494;
 }
 
@@ -970,7 +970,7 @@ exports[`Buttons Outline Button renders correctly 1`] = `
 }
 
 .c2:disabled {
-  background-color: #FFFFFF;
+  background-color: transparent;
   color: #949494;
 }
 
@@ -1231,7 +1231,7 @@ exports[`Buttons Outline Button renders correctly in disabled state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #FFFFFF;
+  background-color: transparent;
   color: #949494;
 }
 
@@ -1523,7 +1523,7 @@ exports[`Buttons Outline Button renders correctly in loading state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #FFFFFF;
+  background-color: transparent;
   color: #949494;
 }
 

--- a/src/atoms/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/atoms/Button/__snapshots__/Button.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Buttons Link Button renders correctly 1`] = `
 }
 
 .c2:disabled {
-  background-color: #111111;
+  background-color: #FFFFFF;
   color: #949494;
 }
 
@@ -361,7 +361,7 @@ exports[`Buttons Link Button renders correctly in disabled state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #111111;
+  background-color: #FFFFFF;
   color: #949494;
 }
 
@@ -677,7 +677,7 @@ exports[`Buttons Link Button renders correctly in loading state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #111111;
+  background-color: #FFFFFF;
   color: #949494;
 }
 
@@ -970,7 +970,7 @@ exports[`Buttons Outline Button renders correctly 1`] = `
 }
 
 .c2:disabled {
-  background-color: #111111;
+  background-color: #FFFFFF;
   color: #949494;
 }
 
@@ -1231,7 +1231,7 @@ exports[`Buttons Outline Button renders correctly in disabled state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #111111;
+  background-color: #FFFFFF;
   color: #949494;
 }
 
@@ -1523,7 +1523,7 @@ exports[`Buttons Outline Button renders correctly in loading state 1`] = `
 }
 
 .c2:disabled {
-  background-color: #111111;
+  background-color: #FFFFFF;
   color: #949494;
 }
 

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -29,6 +29,7 @@ export const buttonTextStyle = ({ theme }: any) => css`
 export const BaseButton = styled.button<ButtonProps>`
   ${({ theme, loading, small, block }) => css`
     border-radius: ${theme.borderRadius.button};
+
     cursor: pointer;
     font-size: ${theme.fontSizes.button};
     font-weight: 600;
@@ -38,32 +39,39 @@ export const BaseButton = styled.button<ButtonProps>`
     outline: none;
     text-decoration: none;
     text-transform: uppercase;
+
     &:disabled {
       cursor: not-allowed;
       pointer-events: none;
     }
+
     // icon tag
     i {
       margin-right: ${theme.ruler[2]}px;
     }
+
     ${loading &&
       css`
         pointer-events: none;
         cursor: disabled;
+
         i {
           opacity: 0;
         }
       `}
+
     ${small &&
       css`
         height: ${theme.dimensions.button.small.height};
         padding: ${theme.dimensions.button.small.padding};
       `}
+
     ${block &&
       css`
         display: block;
         width: 100%;
       `}
+
   `}
 `;
 
@@ -72,25 +80,31 @@ export const PrimaryButton = styled(BaseButton)`
     background: ${theme.colors.primary};
     border: 1px solid ${theme.colors.primary};
     color: ${theme.colors.whiteDenim};
+
     &:hover {
       background-color: ${theme.colors.green900};
     }
+
     &:focus {
       background-color: ${theme.colors.green700};
     }
+
     &:disabled {
       background-color: ${theme.colors.blueSmoke};
       border-color: ${theme.colors.blueSmoke};
     }
+
     i:before {
       color: ${theme.colors.whiteDenim};
     }
+
     ${loading &&
       css`
         color: transparent !important;
         background-color: ${theme.colors.blueSmoke};
         border-color: ${theme.colors.blueSmoke};
         position: relative;
+
         :after {
           animation: ${rotate360} 0.5s linear infinite;
           border: 0.1rem solid ${theme.colors.whiteDenim};
@@ -120,66 +134,86 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
   ${({ theme, loading, color }) => css`
     background: transparent;
     color: ${theme.colors.primary};
+
     i:before {
       color: ${theme.colors.primary};
     }
+
     &:hover {
       border-color: ${theme.colors.green900};
       color: ${theme.colors.green900};
       background-color: transparent;
+
       i:before {
         color: ${theme.colors.green900};
       }
     }
+
     &:focus {
       background-color: ${makeOpaque(theme.colors.green600, 0.1)};
     }
+
     &:disabled {
       background-color: transparent;
       color: ${theme.colors.blueSmoke};
+
       i:before {
         color: ${theme.colors.blueSmoke};
       }
     }
+
     ${color === 'black' &&
       css`
         border-color: ${theme.colors.blackBetty};
         color: ${theme.colors.backToBlack};
+
         i:before {
           color: ${theme.colors.backToBlack};
         }
+
         &:hover {
           border-color: ${theme.colors.backToBlack};
           color: ${theme.colors.backToBlack};
+
           i:before {
             color: ${theme.colors.backToBlack};
           }
         }
+
         &:focus {
           background-color: ${theme.colors.macyGrey};
         }
       `}
+
     ${color === 'white' &&
       css`
         border-color: ${theme.colors.whiteDenim};
         color: ${theme.colors.whiteDenim};
         background-color: transparent;
+
         i:before {
           color: ${theme.colors.whiteDenim};
         }
+
         &:hover {
           border-color: ${theme.colors.whiteDenim};
           color: ${theme.colors.whiteDenim};
           background-color: transparent;
+
           i:before {
             color: ${theme.colors.whiteDenim};
           }
         }
+
         &:focus {
           border-color: ${theme.colors.silverSprings};
           background: rgba(219, 219, 219, 0.1); //macyGrey at 10%
         }
+        &:disabled {
+          background-color: ${theme.colors.backToBlack};
+        }
       `}
+
     ${loading &&
       css`
         :after {
@@ -196,18 +230,23 @@ export const LinkButton = styled(OutlineButton)`
     background: ${theme.colors.whiteDenim};
     border: none;
     color: ${theme.colors.primary};
+
     i:before {
       color: ${theme.colors.primary};
     }
+
     &:hover {
       color: ${theme.colors.green900};
+
       i:before {
         color: ${theme.colors.green900};
       }
     }
+
     &:focus {
       background-color: ${makeOpaque(theme.colors.green600, 0.1)};
     }
+
     &:disabled {
       background-color: ${theme.colors.whiteDenim};
     }

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -29,7 +29,6 @@ export const buttonTextStyle = ({ theme }: any) => css`
 export const BaseButton = styled.button<ButtonProps>`
   ${({ theme, loading, small, block }) => css`
     border-radius: ${theme.borderRadius.button};
-
     cursor: pointer;
     font-size: ${theme.fontSizes.button};
     font-weight: 600;
@@ -39,39 +38,32 @@ export const BaseButton = styled.button<ButtonProps>`
     outline: none;
     text-decoration: none;
     text-transform: uppercase;
-
     &:disabled {
       cursor: not-allowed;
       pointer-events: none;
     }
-
     // icon tag
     i {
       margin-right: ${theme.ruler[2]}px;
     }
-
     ${loading &&
       css`
         pointer-events: none;
         cursor: disabled;
-
         i {
           opacity: 0;
         }
       `}
-
     ${small &&
       css`
         height: ${theme.dimensions.button.small.height};
         padding: ${theme.dimensions.button.small.padding};
       `}
-
     ${block &&
       css`
         display: block;
         width: 100%;
       `}
-
   `}
 `;
 
@@ -80,31 +72,25 @@ export const PrimaryButton = styled(BaseButton)`
     background: ${theme.colors.primary};
     border: 1px solid ${theme.colors.primary};
     color: ${theme.colors.whiteDenim};
-
     &:hover {
       background-color: ${theme.colors.green900};
     }
-
     &:focus {
       background-color: ${theme.colors.green700};
     }
-
     &:disabled {
       background-color: ${theme.colors.blueSmoke};
       border-color: ${theme.colors.blueSmoke};
     }
-
     i:before {
       color: ${theme.colors.whiteDenim};
     }
-
     ${loading &&
       css`
         color: transparent !important;
         background-color: ${theme.colors.blueSmoke};
         border-color: ${theme.colors.blueSmoke};
         position: relative;
-
         :after {
           animation: ${rotate360} 0.5s linear infinite;
           border: 0.1rem solid ${theme.colors.whiteDenim};
@@ -134,86 +120,66 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
   ${({ theme, loading, color }) => css`
     background: transparent;
     color: ${theme.colors.primary};
-
     i:before {
       color: ${theme.colors.primary};
     }
-
     &:hover {
       border-color: ${theme.colors.green900};
       color: ${theme.colors.green900};
       background-color: transparent;
-
       i:before {
         color: ${theme.colors.green900};
       }
     }
-
     &:focus {
       background-color: ${makeOpaque(theme.colors.green600, 0.1)};
     }
-
     &:disabled {
-      background-color: ${theme.colors.whiteDenim};
+      background-color: transparent;
       color: ${theme.colors.blueSmoke};
-
       i:before {
         color: ${theme.colors.blueSmoke};
       }
     }
-
     ${color === 'black' &&
       css`
         border-color: ${theme.colors.blackBetty};
         color: ${theme.colors.backToBlack};
-
         i:before {
           color: ${theme.colors.backToBlack};
         }
-
         &:hover {
           border-color: ${theme.colors.backToBlack};
           color: ${theme.colors.backToBlack};
-
           i:before {
             color: ${theme.colors.backToBlack};
           }
         }
-
         &:focus {
           background-color: ${theme.colors.macyGrey};
         }
       `}
-
     ${color === 'white' &&
       css`
         border-color: ${theme.colors.whiteDenim};
         color: ${theme.colors.whiteDenim};
         background-color: transparent;
-
         i:before {
           color: ${theme.colors.whiteDenim};
         }
-
         &:hover {
           border-color: ${theme.colors.whiteDenim};
           color: ${theme.colors.whiteDenim};
           background-color: transparent;
-
           i:before {
             color: ${theme.colors.whiteDenim};
           }
         }
-
         &:focus {
           border-color: ${theme.colors.silverSprings};
           background: rgba(219, 219, 219, 0.1); //macyGrey at 10%
         }
-        &:disabled {
-          background-color: ${theme.colors.backToBlack};
-        }
       `}
-
     ${loading &&
       css`
         :after {
@@ -230,23 +196,18 @@ export const LinkButton = styled(OutlineButton)`
     background: ${theme.colors.whiteDenim};
     border: none;
     color: ${theme.colors.primary};
-
     i:before {
       color: ${theme.colors.primary};
     }
-
     &:hover {
       color: ${theme.colors.green900};
-
       i:before {
         color: ${theme.colors.green900};
       }
     }
-
     &:focus {
       background-color: ${makeOpaque(theme.colors.green600, 0.1)};
     }
-
     &:disabled {
       background-color: ${theme.colors.whiteDenim};
     }

--- a/src/atoms/Button/index.tsx
+++ b/src/atoms/Button/index.tsx
@@ -154,7 +154,7 @@ export const OutlineButton = styled(PrimaryButton)<OutlineButtonProps>`
     }
 
     &:disabled {
-      background-color: ${theme.colors.backToBlack};
+      background-color: ${theme.colors.whiteDenim};
       color: ${theme.colors.blueSmoke};
 
       i:before {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Test this by running `yarn start` to open the storybook, then check the Button story, go to the Outline button, and check the disabled state to true. (see screenshot)

<img width="948" alt="Screen Shot 2020-11-20 at 10 40 37 AM" src="https://user-images.githubusercontent.com/997701/99819026-eff7b880-2b1c-11eb-9ec8-13296a03c0aa.png">


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

