### PR TITLE
Allow Select component to take a value prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.3.18",
+  "version": "7.3.19",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDisableScroll, useOutsideClick, useKeyDown } from '../';
 
 interface Props<T> {
@@ -9,6 +9,7 @@ interface Props<T> {
   searchable: boolean;
   filterBy?: (option: T, query: string) => boolean;
   defaultOptions: T[];
+  value?: T | null;
 }
 
 interface ReturnProps<T> {
@@ -31,12 +32,19 @@ const useSelect = <T extends {}>({
   defaultOptions,
   searchable,
   filterBy,
+  value,
   onChange
 }: Props<T>): ReturnProps<T> => {
   const ref = useRef<HTMLInputElement>();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState(defaultValue);
   const [inputValue, setInputValue] = useState('');
+
+  useEffect(() => {
+    if (value) {
+      setSelected(value);
+    }
+  }, [value]);
 
   const toggleSelect = (toOpen: boolean) => {
     if (!toOpen && inputValue) {

--- a/src/molecules/Select/README.md
+++ b/src/molecules/Select/README.md
@@ -40,6 +40,7 @@ Table below contains all types of props available in the Select component
 | **placeholder**        | `string`        |         | The placeholder/label to display before a value has been selected                                                     |
 | **getOptionLabel**     | `Function`      |         | Required to determine what to render as the label. Returns the current option object                                  |
 | defaultValue           | `Option / null` |         | If a default value has been set, pass in the reference matching object in.                                            |
+| value                  | `Option / null` |         | If a value has been set, pass in the reference matching object in.                                            |
 | state                  | [Enum](#enum)   | `ready` | The state of the select (ready, loading, or error)                                                                    |
 | searchable             | `Boolean`       |         | Whether the select is searchable                                                                                      |
 | filterBy               | `Function`      |         | A custom filter function that can be passed in                                                                        |

--- a/src/molecules/Select/Select.test.tsx
+++ b/src/molecules/Select/Select.test.tsx
@@ -199,4 +199,14 @@ describe('<Select />', () => {
 
     expect(queryByTestId('select-input')).toHaveValue('Cardiff');
   });
+
+  it('sets the correct selected option when value is given', () => {
+    const mockClick = jest.fn();
+    const { queryByTestId } = setup({
+      onChange: mockClick,
+      value: cities[3]
+    });
+
+    expect(queryByTestId('select-input')).toHaveValue('New York');
+  });
 });

--- a/src/molecules/Select/index.tsx
+++ b/src/molecules/Select/index.tsx
@@ -19,6 +19,7 @@ export interface SelectProps<T> extends OptionsListProps<T> {
   // input props
   placeholder: string;
   defaultValue?: T | null;
+  value?: T | null;
   id?: string;
   name?: string;
   hasError?: boolean;
@@ -50,6 +51,7 @@ const Select = <T extends {}>({
   getPopularOptionsTitle,
   placeholder,
   defaultValue,
+  value,
   id,
   name,
   hasError,
@@ -74,6 +76,7 @@ const Select = <T extends {}>({
     disableScrollWhenOpen,
     getOptionLabel,
     defaultValue,
+    value,
     searchable,
     filterBy,
     defaultOptions,

--- a/storybook/stories/Select.stories.tsx
+++ b/storybook/stories/Select.stories.tsx
@@ -42,6 +42,13 @@ const staticExamples = [
     }
   },
   {
+    title: 'With value',
+    props: {
+      ...defaultProps,
+      value: multiDimensional[11]
+    }
+  },
+  {
     title: 'With advanced getOptionLabel',
     props: {
       ...defaultProps,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Currently the Select component only takes a default value prop, but it's not possible to programmatically update a select value from outside the component. This change adds a value prop that allows us to pass a selected option.

### Motivation and Context
This change is needed in order to allow some more complex form interactions that require programmatically selecting an option in a Select component after some other event happens in a form.

### How Has This Been Tested?
Added an example to Storybook. And a unit test.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

