### PR TITLE
allow Select to be reset programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.3.23",
+  "version": "7.3.22",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.3.22",
+  "version": "7.3.24",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -56,6 +56,7 @@ const useSelect = <T extends {}>({
     } else if (value === null && value !== selected) {
       onOptionClick(null);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, onOptionClick]);
 
   const toggleSelect = (toOpen: boolean) => {

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { useDisableScroll, useOutsideClick, useKeyDown } from '../';
 
 interface Props<T> {
@@ -40,11 +40,23 @@ const useSelect = <T extends {}>({
   const [selected, setSelected] = useState(defaultValue);
   const [inputValue, setInputValue] = useState('');
 
+  const onOptionClick = useCallback(
+    (option: T | null) => {
+      setSelected(option);
+      setIsOpen(false);
+      setInputValue('');
+      onChange(option);
+    },
+    [onChange]
+  );
+
   useEffect(() => {
     if (value) {
       setSelected(value);
+    } else if (value === null) {
+      onOptionClick(null);
     }
-  }, [value]);
+  }, [value, onOptionClick]);
 
   const toggleSelect = (toOpen: boolean) => {
     if (!toOpen && inputValue) {
@@ -59,13 +71,6 @@ const useSelect = <T extends {}>({
   useOutsideClick(ref, () => toggleSelect(false));
 
   useKeyDown('Escape', () => toggleSelect(false));
-
-  const onOptionClick = (option: T | null) => {
-    setSelected(option);
-    setIsOpen(false);
-    setInputValue('');
-    onChange(option);
-  };
 
   const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     const val = e.target.value;

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -56,7 +56,8 @@ const useSelect = <T extends {}>({
     } else if (value === null && selected !== null) {
       onOptionClick(null);
     }
-  }, [value, onOptionClick, selected]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
 
   const toggleSelect = (toOpen: boolean) => {
     if (!toOpen && inputValue) {

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -53,7 +53,7 @@ const useSelect = <T extends {}>({
   useEffect(() => {
     if (value) {
       setSelected(value);
-    } else if (value === null && value !== selected) {
+    } else if (selected) {
       onOptionClick(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -53,7 +53,7 @@ const useSelect = <T extends {}>({
   useEffect(() => {
     if (value) {
       setSelected(value);
-    } else if (selected) {
+    } else if (value === null && selected) {
       onOptionClick(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -53,11 +53,10 @@ const useSelect = <T extends {}>({
   useEffect(() => {
     if (value) {
       setSelected(value);
-    } else if (value === null && selected !== null) {
+    } else if (value === null && value !== selected) {
       onOptionClick(null);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value]);
+  }, [value, onOptionClick]);
 
   const toggleSelect = (toOpen: boolean) => {
     if (!toOpen && inputValue) {

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -56,7 +56,7 @@ const useSelect = <T extends {}>({
     } else if (value === null && selected !== null) {
       onOptionClick(null);
     }
-  }, [value, onOptionClick]);
+  }, [value, onOptionClick, selected]);
 
   const toggleSelect = (toOpen: boolean) => {
     if (!toOpen && inputValue) {

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -53,7 +53,7 @@ const useSelect = <T extends {}>({
   useEffect(() => {
     if (value) {
       setSelected(value);
-    } else if (value === null) {
+    } else if (value === null && selected !== null) {
       onOptionClick(null);
     }
   }, [value, onOptionClick]);

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -53,11 +53,11 @@ const useSelect = <T extends {}>({
   useEffect(() => {
     if (value) {
       setSelected(value);
-    } else if (value === null && selected) {
+    } else if (selected) {
       onOptionClick(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value, onOptionClick]);
+  }, [value]);
 
   const toggleSelect = (toOpen: boolean) => {
     if (!toOpen && inputValue) {

--- a/storybook/stories/Select.stories.tsx
+++ b/storybook/stories/Select.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { withKnobs } from '@storybook/addon-knobs';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
 
 import { Icon, Select, SelectState, MenuItem } from '../../src';
 
@@ -94,46 +94,6 @@ const defaultTypeaheadProps = {
   ...defaultProps,
   searchable: true
 };
-const typeaheadExamples = [
-  {
-    title: 'Static',
-    props: defaultTypeaheadProps
-  },
-  {
-    title: 'Custom FilterBy',
-    props: {
-      ...defaultTypeaheadProps,
-      getOptionLabel: (opt: any) => `${opt.title}, ${opt.country}`,
-      filterBy: (o: any, q: string) =>
-        o.title.indexOf(q) > -1 || o.country.indexOf(q) > -1
-    }
-  },
-  {
-    title: 'Grouped',
-    props: {
-      ...defaultTypeaheadProps,
-      groupBy: (o: any) => o.title.slice(0, 1)
-    }
-  },
-  {
-    title: 'Popular Options',
-    props: {
-      ...defaultTypeaheadProps,
-      popularOptions: multiDimensional.slice(0, 5),
-      getPopularOptionsTitle: (o: any) => `Top ${o.length} cities:`
-    }
-  },
-
-  {
-    title: 'Popular Options with grouped options',
-    props: {
-      ...defaultTypeaheadProps,
-      popularOptions: multiDimensional.slice(0, 5),
-      getPopularOptionsTitle: (o: any) => `Top ${o.length} cities:`,
-      groupBy: (o: any) => o.title.slice(0, 1)
-    }
-  }
-];
 
 storiesOf('Select', module)
   .addDecorator(withKnobs)
@@ -164,30 +124,84 @@ storiesOf('Select', module)
       ))}
     </div>
   ))
-  .add('Typeahead', () => (
-    <div style={{ paddingBottom: '500px' }}>
-      <h1>Typeahead</h1>
+  .add('Typeahead', () => {
+    const nullValue = boolean("Null Value", false);
+    const typeaheadExamples = [
+      {
+        title: 'Static',
+        props: defaultTypeaheadProps
+      },
+      {
+        title: 'With Value',
+        props: {
+          ...defaultTypeaheadProps,
+          value: nullValue ? null : multiDimensional[11],
+        }
+      },
+      {
+        title: 'Custom FilterBy',
+        props: {
+          ...defaultTypeaheadProps,
+          getOptionLabel: (opt: any) => `${opt.title}, ${opt.country}`,
+          filterBy: (o: any, q: string) =>
+            o.title.indexOf(q) > -1 || o.country.indexOf(q) > -1
+        }
+      },
+      {
+        title: 'Grouped',
+        props: {
+          ...defaultTypeaheadProps,
+          groupBy: (o: any) => o.title.slice(0, 1)
+        }
+      },
+      {
+        title: 'Popular Options',
+        props: {
+          ...defaultTypeaheadProps,
+          popularOptions: multiDimensional.slice(0, 5),
+          getPopularOptionsTitle: (o: any) => `Top ${o.length} cities:`
+        }
+      },
 
-      {typeaheadExamples.map(e => (
-        <>
-          <h2>{e.title}</h2>
+      {
+        title: 'Popular Options with grouped options',
+        props: {
+          ...defaultTypeaheadProps,
+          popularOptions: multiDimensional.slice(0, 5),
+          getPopularOptionsTitle: (o: any) => `Top ${o.length} cities:`,
+          groupBy: (o: any) => o.title.slice(0, 1)
+        }
+      }
+    ];
+    console.log('examples, nullValue:');
+    console.log(typeaheadExamples);
+    console.log(nullValue);
 
-          <div style={{ width: '100%', display: 'flex' }}>
-            <Boundary
-              style={{ width: '300px', padding: '20px', marginRight: '10px' }}
-            >
-              <Select<MultiDimensional> {...e.props} />
-            </Boundary>
+    return (
+      <div style={{ paddingBottom: '500px' }}>
+        <h1>Typeahead</h1>
 
-            <Boundary
-              style={{ background: '#000', width: '300px', padding: '20px' }}
-            >
-              <Select<MultiDimensional> invertColor {...e.props} />
-            </Boundary>
-          </div>
+        {typeaheadExamples.map(e => (
+          <>
+            <h2>{e.title}</h2>
 
-          <Spacer />
-        </>
-      ))}
-    </div>
-  ));
+            <div style={{ width: '100%', display: 'flex' }}>
+              <Boundary
+                style={{ width: '300px', padding: '20px', marginRight: '10px' }}
+              >
+                <Select<MultiDimensional> {...e.props} />
+              </Boundary>
+
+              <Boundary
+                style={{ background: '#000', width: '300px', padding: '20px' }}
+              >
+                <Select<MultiDimensional> invertColor {...e.props} />
+              </Boundary>
+            </div>
+
+            <Spacer />
+          </>
+        ))}
+      </div>
+    );
+  });

--- a/storybook/stories/Select.stories.tsx
+++ b/storybook/stories/Select.stories.tsx
@@ -173,9 +173,6 @@ storiesOf('Select', module)
         }
       }
     ];
-    console.log('examples, nullValue:');
-    console.log(typeaheadExamples);
-    console.log(nullValue);
 
     return (
       <div style={{ paddingBottom: '500px' }}>


### PR DESCRIPTION
### Description
Allows the Select to be reset through the `value` prop. Simplified version that has been tested end-2-end. Adds a knob to the Typeahead storybook tests so that maestro testers can more easily preview the reset function. 

### Motivation and Context

Sometimes in a dynamic form we want to reset a Select, for example if some other data has changed. Currently there was a way to programmatically set the value but this effect didn't allow `null|undefined` values.

### How Has This Been Tested?
Tested with [https://github.com/sofarsounds/sofar-client/pull/877](https://github.com/sofarsounds/sofar-client/pull/877) and [https://github.com/sofarsounds/sofar-main/pull/6801](https://github.com/sofarsounds/sofar-main/pull/6801) using yarn link. (react, react-dom and styled-components also need to be yarn linked, see below:)

```
cd ~/maestro
yarn install
yarn build
yarn link
cd node_modules/react
yarn link
cd ../react-dom
yarn link
cd ../styled-component
yarn link

cd ~/sofar-client
yarn link "@sofarsounds/maestro"
yarn link "react"
yarn link "react-dom"
yarn link "styled-components"
```

This can also be tested in the storybook in the Typeahead story by toggling the "null value" knob.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

