### PR TITLE
Allow us to invert colors on dropdown & menu

### DIFF
--- a/src/atoms/Menu/index.tsx
+++ b/src/atoms/Menu/index.tsx
@@ -6,10 +6,11 @@ interface Props {
   width?: string;
   bordered?: boolean;
   depth?: any;
+  invertColor?: boolean;
 }
 
 const Menu = styled.ul<Props>`
-  ${({ depth = 3, theme, width, bordered }) => css`
+  ${({ depth = 3, theme, width, bordered, invertColor }) => css`
     ${withShadow({ depth })};
 
     margin: 0;
@@ -24,6 +25,13 @@ const Menu = styled.ul<Props>`
     ${bordered &&
       css`
         border: 1px solid ${theme.colors.macyGrey};
+      `}
+
+    ${invertColor &&
+      css`
+        border-top: 4px solid ${theme.colors.green400};
+        background-color: ${theme.colors.blackBetty};
+        color: ${theme.colors.whiteDenim};
       `}
   `};
 `;

--- a/src/atoms/MenuHeader/index.tsx
+++ b/src/atoms/MenuHeader/index.tsx
@@ -1,10 +1,10 @@
 import styled, { css } from '../../lib/styledComponents';
 import { Overline } from '../Typography';
 
-export default styled(Overline)`
-  ${({ theme }) => css`
+export default styled(Overline)<any>`
+  ${({ theme, invertColor }) => css`
     padding: ${theme.ruler[1]}px ${theme.ruler[4]}px;
-    background: ${theme.colors.whiteDenim};
+    background: ${invertColor ? 'transparent' : theme.colors.whiteDenim};
     position: sticky;
     display: block;
     top: 0;

--- a/src/atoms/MenuItem/index.tsx
+++ b/src/atoms/MenuItem/index.tsx
@@ -6,30 +6,41 @@ interface Props {
   active?: boolean;
   disabled?: boolean;
   onClick?: () => any;
+  invertColor?: boolean;
   'data-qaid'?: string;
 }
 
 export default styled.li<Props>`
-  ${({ theme, active, disabled }) => css`
+  ${({ theme, active, disabled, invertColor }) => css`
     margin-top: 0px;
     list-style: none;
     padding: ${theme.ruler[2]}px ${theme.ruler[4]}px;
     font-size: ${theme.fontSizes.body2};
     letter-spacing: 0.25px;
-    color: ${theme.colors.backToBlack};
     cursor: pointer;
 
+    color: ${invertColor ? theme.colors.whiteDenim : theme.colors.backToBlack};
+
     &:hover {
-      background-color: ${theme.colors.silverSprings};
+      background-color: ${invertColor
+        ? theme.colors.green400
+        : theme.colors.silverSprings};
+      color: ${invertColor ? theme.colors.backToBlack : 'inherit'};
     }
 
     &:focus {
-      background-color: ${theme.colors.silverSprings};
+      background-color: ${invertColor
+        ? theme.colors.green400
+        : theme.colors.silverSprings};
+      color: ${invertColor ? theme.colors.backToBlack : 'inherit'};
     }
 
     ${active &&
       css`
-        background-color: ${theme.colors.silverSprings};
+        background-color: ${invertColor
+          ? theme.colors.green400
+          : theme.colors.silverSprings};
+        color: ${invertColor ? theme.colors.backToBlack : 'inherit'};
       `}
 
     ${disabled &&

--- a/src/molecules/Dropdown/index.tsx
+++ b/src/molecules/Dropdown/index.tsx
@@ -15,6 +15,7 @@ interface DropdownProps extends PopperProps {
   size?: 'small' | 'large';
   flyoutContainer?: boolean; // TODO rename to `hasFlyoutContainer` ?
   disableScrollWhenOpen?: boolean;
+  invertColor?: boolean;
   'data-qaid'?: string;
   id?: string;
 }
@@ -42,6 +43,7 @@ const Dropdown: React.SFC<DropdownProps> = ({
   offset,
   keepInViewPort,
   size,
+  invertColor,
   'data-qaid': qaId,
   id
 }) => {
@@ -82,7 +84,11 @@ const Dropdown: React.SFC<DropdownProps> = ({
             keepInViewPort={keepInViewPort}
           >
             {flyoutContainer ? (
-              <StyledMenu width={width} data-qaid={`${qaId}-flyout`}>
+              <StyledMenu
+                width={width}
+                data-qaid={`${qaId}-flyout`}
+                invertColor={invertColor}
+              >
                 {children}
               </StyledMenu>
             ) : (

--- a/src/theme/global.ts
+++ b/src/theme/global.ts
@@ -22,11 +22,11 @@ export default createGlobalStyle`
     html,
     * {
       font-family: "${theme.fonts.regular}", sans-serif;
-      color: ${theme.colors.backToBlack};
     }
 
     body {
       font-size: ${theme.fontSizes.base};
+      color: ${theme.colors.backToBlack};
       margin: 0px;
     }
 

--- a/storybook/stories/Dropdown.stories.tsx
+++ b/storybook/stories/Dropdown.stories.tsx
@@ -24,6 +24,7 @@ storiesOf('Dropdown', module)
         disableScrollWhenOpen={boolean('Disable Scroll', false)}
         keepInViewPort={boolean('Keep In ViewPort', false)}
         label="Click me to open the dropdown"
+        invertColor={boolean('Invert Color', false)}
       >
         <b>A Dropdown</b>
         <p>
@@ -51,6 +52,7 @@ storiesOf('Dropdown', module)
             />
           </>
         )}
+        invertColor={boolean('Invert Color', false)}
       >
         <Menu width={'200px'}>
           {cities.slice(0, 4).map((city, index) => (
@@ -71,6 +73,7 @@ storiesOf('Dropdown', module)
         renderLabel={isOpen => (
           <PrimaryButton>{isOpen ? 'Open' : 'Close'}</PrimaryButton>
         )}
+        invertColor={boolean('Invert Color', false)}
       >
         <p style={{ width: '200px' }}>
           I am the contents of a dropdown without a flyout container

--- a/storybook/stories/Menu.stories.tsx
+++ b/storybook/stories/Menu.stories.tsx
@@ -28,9 +28,12 @@ storiesOf('Menu', module)
         width={text('Width', '200px')}
         bordered={boolean('Bordered', false)}
         depth={number('Shadow Depth', 3)}
+        invertColor={boolean('Invert Color', false)}
       >
         {cities.slice(0, number('Number of items', 5)).map(c => (
-          <MenuItem key={c}>{c}</MenuItem>
+          <MenuItem  invertColor={boolean('Invert Color', false)}  key={c}>
+            {c}
+          </MenuItem>
         ))}
       </Menu>
 
@@ -40,12 +43,17 @@ storiesOf('Menu', module)
         width={text('Width', '200px')}
         bordered={boolean('Bordered', false)}
         depth={number('Shadow Depth', 3)}
+        invertColor={boolean('Invert Color', false)}
       >
         {Object.keys(groupedCities).map(firstLetter => (
           <div key={firstLetter}>
-            <MenuHeader>{firstLetter}</MenuHeader>
+            <MenuHeader invertColor={boolean('Invert Color', false)}>
+              {firstLetter}
+            </MenuHeader>
             {groupedCities[firstLetter].map((c: string) => (
-              <MenuItem key={c}>{c}</MenuItem>
+              <MenuItem invertColor={boolean('Invert Color', false)} key={c}>
+                {c}
+              </MenuItem>
             ))}
           </div>
         ))}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
For the new navigation bar on sofar client we need to have the ability
to invert the colors to a dark theme ffor the dropdown and navigation.

As part of this it was needed to edit the global theme so color is not
applied specifically to all fields to allow inheritence from the parent.
This has been moved to the body selector so it should still get applied
to all elements through inheritence

### How Has This Been Tested?
via storybook, no unit tests added as this is all style, and no substance

### Screenshots (if appropriate):

![Screenshot 2021-02-23 at 15 33 45](https://user-images.githubusercontent.com/345801/108866987-a4a5e800-75ec-11eb-8e43-08c6002a94fb.png)
![Screenshot 2021-02-23 at 15 33 32](https://user-images.githubusercontent.com/345801/108866993-a5d71500-75ec-11eb-971b-c51d2bf7c966.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

