### PR TITLE
Specify default link colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/theme/global.ts
+++ b/src/theme/global.ts
@@ -40,6 +40,10 @@ export default createGlobalStyle`
       box-sizing: inherit;
     }
 
+    a {
+      color: ${theme.colors.backToBlack};
+    }
+
     a:link, a:visited {
       text-decoration: none;
     }


### PR DESCRIPTION
A previous update to ensure we can override link colors and inherit from
the parent container meant that unless defined it reverted to browser
defaults.  This sets the link color within the global theme whilst still
allowing overrides