### PR TITLE
Ability to have a Visual of the Maestro Buildpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const TerserPlugin = require('terser-webpack-plugin');
 const nodeExternals = require('webpack-node-externals');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = {
   mode: 'production',
@@ -17,6 +18,12 @@ module.exports = {
     // minimize: false
     minimizer: [new TerserPlugin()]
   },
+  plugins: [
+    new BundleAnalyzerPlugin({
+      concatenateModules: true,
+      analyzerMode: 'static',
+    })
+  ],
   module: {
     rules: [
       {


### PR DESCRIPTION
### Description
Integrated `webpack-build-analyzer` on maestro which now can be run using `yarn build` to get an idea of what constitutes the Maestro production bundle.

### Motivation and Context
- There was some confusion and blindspot trying to understand what constituted the maestro production build which led to integrating this.

### How Has This Been Tested?
- Go to maestro.
- Run `yarn build`.
- You should see a new browser window popup with these bundle view.

### Screenshots (if appropriate):
![Screen Shot 2021-03-03 at 12 48 56 PM](https://user-images.githubusercontent.com/72412303/109848958-d6672080-7c76-11eb-99fe-505c2d9a1f28.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

