### PR TITLE
Extend IconLabel functionalities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.4.4",
+  "version": "7.4.5",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/molecules/IconLabel/IconLabel.test.tsx
+++ b/src/molecules/IconLabel/IconLabel.test.tsx
@@ -42,21 +42,6 @@ describe('<IconLabel />', () => {
     expect(queryByTestId('iconlabel-icon')).toHaveClass('icon-party');
   });
 
-  it('truncates long label text', () => {
-    const { queryByTestId } = setup({
-      labelText: 'Long Venue Text',
-      color: 'purplePills',
-      icon: 'party'
-    });
-    expect(queryByTestId('iconlabel-icon-wrapper')).toBeInTheDocument();
-    expect(queryByTestId('iconlabel-text')).toBeInTheDocument();
-    expect(queryByTestId('iconlabel-text')).toHaveTextContent('Long Venue...');
-    checkStyleRules(queryByTestId('iconlabel-icon-wrapper'), {
-      'background-color': theme.colors.whiteDenim
-    });
-    expect(queryByTestId('iconlabel-icon')).toHaveClass('icon-party');
-  });
-
   it('renders inverted icon-wrapper when invertIcon set to true', () => {
     const { queryByTestId } = setup({
       labelText: 'Venue Text',

--- a/src/molecules/IconLabel/index.tsx
+++ b/src/molecules/IconLabel/index.tsx
@@ -23,6 +23,7 @@ const IconLabelText = styled.div<IconLabelTextProps>`
     width: 100%;
     overflow: hidden;
     white-space: nowrap;
+    text-overflow: ellipsis;
     ${draft &&
       css`
         color: ${theme.colors.macyGrey};
@@ -45,6 +46,8 @@ const IconWrapper = styled.div<IconWrapperProps>`
     display: flex;
     align-items: center;
     justify-content: center;
+    min-width: ${theme.ruler[8]}px;
+    min-height: ${theme.ruler[8]}px;
     width: ${theme.ruler[8]}px;
     height: ${theme.ruler[8]}px;
     border-radius: ${theme.ruler[4]}px;
@@ -72,6 +75,8 @@ interface Props {
   draft?: boolean;
   color?: Colors;
   invertIcon?: boolean;
+  className?: string;
+  emptyIcon?: boolean;
 }
 
 interface IconWrapperProps {
@@ -83,8 +88,8 @@ interface IconLabelTextProps {
   draft: boolean;
 }
 
-const truncateText = (text: string, length: number) =>
-  text.length > length ? `${text.substring(0, length).trim()}...` : text;
+// const truncateText = (text: string, length: number) =>
+//   text.length > length ? `${text.substring(0, length).trim()}...` : text;
 
 const IconLabel: React.SFC<Props> = ({
   icon,
@@ -94,10 +99,17 @@ const IconLabel: React.SFC<Props> = ({
   labelText,
   onClick = () => {},
   draft = false,
-  invertIcon = false
+  invertIcon = false,
+  className = '',
+  emptyIcon = false
 }) => {
   return (
-    <LabelWrapper key={name} data-qaid="label" onClick={onClick}>
+    <LabelWrapper
+      key={name}
+      data-qaid="label"
+      onClick={onClick}
+      className={className}
+    >
       {draft && (
         <IconWrapper
           color={'macyGrey'}
@@ -128,6 +140,13 @@ const IconLabel: React.SFC<Props> = ({
           <Icon name={icon} size={iconSize} data-qaid="iconlabel-icon" />
         </IconWrapper>
       )}
+      {emptyIcon && (
+        <IconWrapper
+          color={color || 'macyGrey'}
+          inverted={invertIcon}
+          data-qaid="iconlabel-icon-wrapper"
+        />
+      )}
       {!icon && !imageUrl && !draft && !labelText && (
         <IconWrapper
           color="macyGrey"
@@ -138,7 +157,7 @@ const IconLabel: React.SFC<Props> = ({
         </IconWrapper>
       )}
       <IconLabelText draft={draft} data-qaid="iconlabel-text">
-        {labelText && truncateText(labelText, 11)}
+        {labelText}
       </IconLabelText>
     </LabelWrapper>
   );

--- a/src/molecules/IconLabel/index.tsx
+++ b/src/molecules/IconLabel/index.tsx
@@ -8,18 +8,19 @@ const LabelWrapper = styled.div`
   ${({ theme }) => css`
     cursor: pointer;
     background-color: ${theme.colors.whiteDenim};
-    padding: ${theme.ruler[2]}px;
+    padding: ${theme.ruler[1]}px ${theme.ruler[2]}px;
     height: ${theme.ruler[12]}px;
     border-radius: ${theme.ruler[6]}px;
-    font-size: 14px;
+    font-size: 12px;
     display: flex;
+    align-items: center;
     width: 160px;
   `}
 `;
 
 const IconLabelText = styled.div<IconLabelTextProps>`
   ${({ theme, draft }) => css`
-    padding: ${theme.ruler[2]}px;
+    padding: 0px ${theme.ruler[2]}px;
     width: 100%;
     overflow: hidden;
     white-space: nowrap;
@@ -29,6 +30,20 @@ const IconLabelText = styled.div<IconLabelTextProps>`
         color: ${theme.colors.macyGrey};
       `}
   `}
+`;
+
+const UpperText = styled(IconLabelText)`
+  font-size: 10px;
+  letter-spacing: 1.5px;
+`;
+
+const LabelsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  justify-content: center;
 `;
 
 const ImageWrapper = styled.div`
@@ -71,6 +86,7 @@ interface Props {
   iconSize?: string;
   imageUrl?: string;
   labelText?: string;
+  upperLabelText?: string;
   onClick?: any;
   draft?: boolean;
   color?: Colors;
@@ -88,15 +104,13 @@ interface IconLabelTextProps {
   draft: boolean;
 }
 
-// const truncateText = (text: string, length: number) =>
-//   text.length > length ? `${text.substring(0, length).trim()}...` : text;
-
 const IconLabel: React.SFC<Props> = ({
   icon,
   iconSize = '14px',
   color,
   imageUrl,
   labelText,
+  upperLabelText,
   onClick = () => {},
   draft = false,
   invertIcon = false,
@@ -156,9 +170,16 @@ const IconLabel: React.SFC<Props> = ({
           <Icon name={'plus'} size={iconSize} data-qaid="iconlabel-icon" />
         </IconWrapper>
       )}
-      <IconLabelText draft={draft} data-qaid="iconlabel-text">
-        {labelText}
-      </IconLabelText>
+      <LabelsWrapper>
+        {upperLabelText && (
+          <UpperText draft={draft} data-qaid="iconlabel-upper-label-text">
+            {upperLabelText}
+          </UpperText>
+        )}
+        <IconLabelText draft={draft} data-qaid="iconlabel-text">
+          {labelText}
+        </IconLabelText>
+      </LabelsWrapper>
     </LabelWrapper>
   );
 };

--- a/storybook/stories/IconLabel.stories.tsx
+++ b/storybook/stories/IconLabel.stories.tsx
@@ -54,6 +54,22 @@ storiesOf('IconLabel', module)
           labelText="With empty icon"
         />
         <Spacer mt={2} />
+        <IconLabel
+          color="purplePills"
+          icon="party"
+          invertIcon
+          upperLabelText="AUDIO"
+          labelText="Adam West"
+        />
+        <Spacer mt={2} />
+        <IconLabel
+          color="purplePills"
+          icon="party"
+          invertIcon
+          upperLabelText="SPACE ENGINEER"
+          labelText="Neil A. Armstrong Jr."
+        />
+        <Spacer mt={2} />
         <StyledIconLabel
           color="purplePills"
           icon="party"

--- a/storybook/stories/IconLabel.stories.tsx
+++ b/storybook/stories/IconLabel.stories.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs'
+import { withDesign } from 'storybook-addon-designs';
 import styled from 'styled-components';
 
 import { IconLabel, Spacer } from '../../src';
 
 const Container = styled.div`
   padding: 20px;
-  background: #F3F3F3;
+  background: #f3f3f3;
+`;
+
+const StyledIconLabel = styled(IconLabel)`
+  width: 100%;
 `;
 
 storiesOf('IconLabel', module)
@@ -20,28 +24,41 @@ storiesOf('IconLabel', module)
       <Container>
         <IconLabel />
         <Spacer mt={2} />
-        <IconLabel 
-          draft 
-          labelText="Venue Name" 
+        <IconLabel draft labelText="Venue Name" />
+        <Spacer mt={2} />
+        <IconLabel
+          labelText="Venue Name"
+          imageUrl={
+            'https://images.prismic.io/sofar-blog/3d748cb2-c88e-41ce-bd39-6ed00471efb9_3%403x.jpg?auto=compress,format&rect=0,68,702,566&w=556&h=448'
+          }
         />
         <Spacer mt={2} />
-        <IconLabel 
-          labelText="Venue Name" 
-          imageUrl={'https://images.prismic.io/sofar-blog/3d748cb2-c88e-41ce-bd39-6ed00471efb9_3%403x.jpg?auto=compress,format&rect=0,68,702,566&w=556&h=448'}
-        />
-        <Spacer mt={2} />
-        <IconLabel 
-          color="orangeCrush" 
-          icon="mail" 
+        <IconLabel
+          color="orangeCrush"
+          icon="mail"
           iconSize="10px"
-          labelText="Venue Name" 
+          labelText="Venue Name"
         />
         <Spacer mt={2} />
-        <IconLabel 
-          color="purplePills" 
-          icon="party" 
-          invertIcon 
-          labelText="15 Landsdowne St. Boston, MA" 
+        <IconLabel
+          color="purplePills"
+          icon="party"
+          invertIcon
+          labelText="15 Landsdowne St. Boston, MA"
+        />
+        <Spacer mt={2} />
+        <IconLabel
+          color="green600"
+          emptyIcon={true}
+          invertIcon
+          labelText="With empty icon"
+        />
+        <Spacer mt={2} />
+        <StyledIconLabel
+          color="purplePills"
+          icon="party"
+          invertIcon
+          labelText="This is an IconLabel component styled to have full width using styled components"
         />
       </Container>
     </>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Extend IconLabel component to:

- Allow the component to be styled using styled components
- Prevent label text from getting truncated if not needed
- Allow the component to render a colored circle without an icon when needed
- Allow the component to take an upper label text prop that is displayed above the main label

### Motivation and Context
We need these changes to implement the styles required for the Team section on the Events Details modal. Screenshot of the mocks:

![Screen Shot 2021-03-19 at 14 33 50](https://user-images.githubusercontent.com/1944996/111820373-29201980-88c0-11eb-8021-facfdf205510.png)

### How Has This Been Tested?
You can test this by going to storybook and checking that all implementations of the IconLabel component look good. Play around with new implementations.

### Screenshots (if appropriate):

<img width="1210" alt="Screen Shot 2021-03-19 at 14 29 46" src="https://user-images.githubusercontent.com/1944996/111820438-4228ca80-88c0-11eb-8483-c8c1bae62cf5.png">

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

