### PR TITLE
add zIndex as Popper prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.4.8",
+  "version": "7.4.9",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/Popper/index.tsx
+++ b/src/atoms/Popper/index.tsx
@@ -20,6 +20,7 @@ export interface PopperProps {
   flip?: boolean;
   reactToChange?: number | boolean;
   width?: string;
+  zIndex?: number;
 }
 
 interface Props extends PopperProps {
@@ -49,7 +50,8 @@ const Popper: React.SFC<Props> = ({
   flip = false,
   children,
   reactToChange,
-  width
+  width,
+  zIndex = 500
 }) => {
   const popoverRef = useRef<HTMLDivElement>();
   const [calculatedPosition, setCalculatedPosition] = useState<
@@ -127,9 +129,9 @@ const Popper: React.SFC<Props> = ({
       style: {
         top: `${y}px`,
         left: `${x}px`,
-        zIndex: 500,
         position: 'fixed',
-        width: width === 'auto' ? anchorElWidth : width
+        width: width === 'auto' ? anchorElWidth : width,
+        zIndex
       }
     });
   }
@@ -140,9 +142,9 @@ const Popper: React.SFC<Props> = ({
       style={{
         top: `${y}px`,
         left: `${x}px`,
-        zIndex: 500,
         position: 'fixed',
-        width: width === 'auto' ? anchorElWidth : width
+        width: width === 'auto' ? anchorElWidth : width,
+        zIndex
       }}
     >
       {typeof children === 'function' ? children({ isFlipped }) : children}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This PR adds a zIndex prop to the Popper component, which defaults to 500. This shouldn't change any functionality but will allow components that use Popper to override the zIndex of 500 which was being hard coded before. 

### Motivation and Context
We would like to customize the sofar-client InfoBox component zIndex so that it will render underneath the navbar.

### How Has This Been Tested?
The Popper should work as expected in storybook, with no change in functionality or visual appearance.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

