### PR TITLE
copy streamline-react-wrapper component into atoms

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
       "<rootDir>/src/test/setupTests.ts"
     ],
     "moduleNameMapper": {
-      "\\.(eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/src/test/fileMock.ts"
+      "\\.(eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|css)$": "<rootDir>/src/test/fileMock.ts"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.4.11",
+  "version": "7.4.12",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/atoms/StreamlineIcon/StreamlineIcon.css
+++ b/src/atoms/StreamlineIcon/StreamlineIcon.css
@@ -1,0 +1,33 @@
+.Streamline_Icon {
+  display: inline-block;
+}
+
+.Streamline_Icon--animated {
+  animation-duration: 1s;
+  animation-fill-mode: both;
+  transform-origin: center;
+  animation-timing-function: linear;
+}
+
+.Streamline_Icon--spin {
+  animation-name: rotate;
+  animation-duration: 2s;
+}
+
+.Streamline_Icon--infinite {
+  animation-iteration-count: infinite;
+}
+
+.Streamline_Animation--fast {
+  animation-duration: 1s;
+}
+
+.Streamline_Animation--ease_in_out {
+  animation-timing-function: ease-in-out;
+}
+
+@keyframes rotate {
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/atoms/StreamlineIcon/index.tsx
+++ b/src/atoms/StreamlineIcon/index.tsx
@@ -1,0 +1,118 @@
+import React, { FunctionComponent } from 'react';
+
+import './StreamlineIcon.css';
+
+type iconSlug = string;
+type iconWidth = number;
+type iconHeight = number;
+interface IconOptions {
+  fill: string;
+  stroke: string;
+  'stroke-linecap': 'butt' | 'round' | 'square' | 'inherit';
+  'stroke-linejoin': 'miter' | 'round' | 'bevel' | 'inherit';
+  'stroke-width': number | string;
+}
+type iconRepresentation = string;
+export type Icon = [
+  iconSlug,
+  iconWidth,
+  iconHeight,
+  IconOptions[],
+  iconRepresentation[]
+];
+
+const StreamlineIcon: FunctionComponent<{
+  icon: Icon;
+  spin?: boolean;
+  infinite?: boolean;
+  easeInOut?: boolean;
+  fast?: boolean;
+  size?: number;
+  fill?: string;
+  stroke?: string;
+  width?: number;
+  height?: number;
+  customClassName?: string;
+}> = ({
+  icon,
+  fill,
+  stroke,
+  width,
+  height,
+  customClassName,
+  size,
+  spin = false,
+  infinite = false,
+  fast = false,
+  easeInOut = false
+}) => {
+  const getClassName = () => {
+    const className = ['Streamline_Icon'];
+    if (spin)
+      className.push('Streamline_Icon--spin', 'Streamline_Icon--animated');
+    if (infinite) className.push('Streamline_Icon--infinite');
+    if (fast) className.push('Streamline_Animation--fast');
+    if (easeInOut) className.push('Streamline_Animation--ease_in_out');
+    if (customClassName) className.push(customClassName);
+
+    return className.join(' ');
+  };
+
+  let shouldResize = true;
+  let finalWidth = icon[1];
+  let finalHeight = icon[2];
+
+  if (size) {
+    shouldResize = size !== finalWidth;
+    finalWidth = size;
+    finalHeight = size;
+  } else {
+    if (height && height !== finalHeight) {
+      finalHeight = height;
+      shouldResize = true;
+    }
+
+    if (width && width !== finalWidth) {
+      finalWidth = width;
+      shouldResize = true;
+    }
+  }
+
+  const renderPaths = () =>
+    icon[4].map((path, index) => (
+      <path
+        fill={fill || icon[3][index]['fill']}
+        stroke={stroke || icon[3][index]['stroke']}
+        strokeLinecap={icon[3][index]['stroke-linecap']}
+        strokeLinejoin={icon[3][index]['stroke-linejoin']}
+        strokeWidth={icon[3][index]['stroke-width']}
+        transform={icon[3][index]['transform']}
+        key={path}
+        d={path}
+      />
+    ));
+
+  return (
+    <i className={getClassName()}>
+      <svg
+        viewBox={`0 0 ${finalWidth} ${finalHeight}`}
+        style={{ width: finalWidth, height: finalHeight }}
+        width={finalWidth}
+        height={finalHeight}
+      >
+        {shouldResize ? (
+          <g
+            transform={`scale(${finalWidth / icon[1]},${finalHeight /
+              icon[2]})`}
+          >
+            {renderPaths()}
+          </g>
+        ) : (
+          renderPaths()
+        )}
+      </svg>
+    </i>
+  );
+};
+
+export default StreamlineIcon;

--- a/src/atoms/StreamlineIcon/index.tsx
+++ b/src/atoms/StreamlineIcon/index.tsx
@@ -1,3 +1,7 @@
+/**
+This file is copied from the now deprecated streamline-react-wrapper package.
+It should be removed once we have migrated to the new streamlinehq package.
+*/
 import React, { FunctionComponent } from 'react';
 
 import './StreamlineIcon.css';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,3 +70,5 @@ export {
   keyframes,
   ServerStyleSheet
 } from './lib/styledComponents';
+
+export { default as StreamlineIcon } from './atoms/StreamlineIcon';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

The original plan was to self-host the streamline-react-wrapper repo and install it via the github URL, but it was having trouble resolving the package, and the wrapper is just a simple React component mapping some props to CSS classes with no dependencies, so I think it makes sense to just copy the component into our `atoms` for now. It will be used the same way on the sofar-client side so no other client changes should need to be made. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

