### PR TITLE
IconLabel: Removed fixed width from default of component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.4.14",
+  "version": "7.4.15",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/molecules/IconLabel/index.tsx
+++ b/src/molecules/IconLabel/index.tsx
@@ -14,7 +14,6 @@ const LabelWrapper = styled.div`
     font-size: 12px;
     display: flex;
     align-items: center;
-    width: 160px;
   `}
 `;
 

--- a/storybook/stories/IconLabel.stories.tsx
+++ b/storybook/stories/IconLabel.stories.tsx
@@ -12,7 +12,7 @@ const Container = styled.div`
 `;
 
 const StyledIconLabel = styled(IconLabel)`
-  width: 100%;
+  width: 200px;
 `;
 
 storiesOf('IconLabel', module)
@@ -74,8 +74,7 @@ storiesOf('IconLabel', module)
           color="purplePills"
           icon="party"
           invertIcon
-          labelText="This is an IconLabel component styled to have full width using styled components"
-        />
+          labelText="200px Set-width" />
       </Container>
     </>
   ));


### PR DESCRIPTION
### Description
Set the width in components where we use IconLabel and set the default to 100%. Updated IconLabel story.

related sofar-client PR: https://github.com/sofarsounds/sofar-client/pull/1546

### Motivation and Context
Width of the IconLabel now adjusts to container so it doesn't leave weird gaps or alignment issues where it's used.

### How Has This Been Tested?
Pull down this branch on sofar-client and link it to this local version of Maestro ([Directions on how to do that can be found here](https://sofarsounds.atlassian.net/wiki/spaces/ST/pages/1350565905/Developing+Maestro+and+Sofar+Client+Locally)). 

Test concert planner at phone and tablet widths using Chrome device emulator (or probably just adjusting the width of the window):
- Event Planner Card: Artists and Venue 
- Event Planner Expand Details Modal: Team tab

### Screenshots (if appropriate):

![Screen Shot 2021-09-29 at 5 15 54 PM](https://user-images.githubusercontent.com/3356406/135535094-70064a47-ef12-4722-8fba-44a7279c11f7.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

