### PR TITLE
FX-1895 Allow for the Select component to be a controlled input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ storybook-static
 # Jetbrains IDEs
 .idea
 
+# VS Code IDE
+.vscode
+
 .npmrc
 
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sofarsounds/maestro",
-  "version": "7.4.19",
+  "version": "7.4.20",
   "description": "The official sofar sounds react uikit library",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,5 +5,5 @@ export { default as usePosition } from './usePosition';
 export { default as useScrollPosition } from './useScrollPosition';
 export { default as useWindowSize } from './useWindowSize';
 export { default as usePrev } from './usePrev';
-export { default as useSelect } from './useSelect';
+export { default as useSelect, ControlledInputStateValue } from './useSelect';
 export { default as useDeviceDetector } from './useDeviceDetector';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,5 +5,5 @@ export { default as usePosition } from './usePosition';
 export { default as useScrollPosition } from './useScrollPosition';
 export { default as useWindowSize } from './useWindowSize';
 export { default as usePrev } from './usePrev';
-export { default as useSelect, ControlledInputStateValue } from './useSelect';
+export { default as useSelect } from './useSelect';
 export { default as useDeviceDetector } from './useDeviceDetector';

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useDisableScroll, useOutsideClick, useKeyDown } from '../';
 
+export interface ControlledInputStateValue {
+  inputValue: string;
+  setInputValue: React.Dispatch<React.SetStateAction<string>>;
+}
+
 interface Props<T> {
   onChange: (option: T | null) => void;
   defaultValue?: T | null;
@@ -10,6 +15,7 @@ interface Props<T> {
   filterBy?: (option: T, query: string) => boolean;
   defaultOptions: T[];
   value?: T | null;
+  controlledInputStateValue?: ControlledInputStateValue;
 }
 
 interface ReturnProps<T> {
@@ -33,12 +39,20 @@ const useSelect = <T extends {}>({
   searchable,
   filterBy,
   value,
-  onChange
+  onChange,
+  controlledInputStateValue
 }: Props<T>): ReturnProps<T> => {
   const ref = useRef<HTMLInputElement>();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState(defaultValue);
-  const [inputValue, setInputValue] = useState('');
+  const [uncontrolledInputValue, setUncontrolledInputValue] = useState('');
+
+  const inputValue = controlledInputStateValue
+    ? controlledInputStateValue.inputValue
+    : uncontrolledInputValue;
+  const setInputValue = controlledInputStateValue
+    ? controlledInputStateValue.setInputValue
+    : setUncontrolledInputValue;
 
   const onOptionClick = useCallback(
     (option: T | null) => {

--- a/src/hooks/useSelect/index.tsx
+++ b/src/hooks/useSelect/index.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useDisableScroll, useOutsideClick, useKeyDown } from '../';
 
-export interface ControlledInputStateValue {
-  inputValue: string;
-  setInputValue: React.Dispatch<React.SetStateAction<string>>;
-}
-
 interface Props<T> {
   onChange: (option: T | null) => void;
   defaultValue?: T | null;
@@ -15,7 +10,8 @@ interface Props<T> {
   filterBy?: (option: T, query: string) => boolean;
   defaultOptions: T[];
   value?: T | null;
-  controlledInputStateValue?: ControlledInputStateValue;
+  controlledInputValue?: string;
+  setControlledInputValue?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 interface ReturnProps<T> {
@@ -40,18 +36,19 @@ const useSelect = <T extends {}>({
   filterBy,
   value,
   onChange,
-  controlledInputStateValue
+  controlledInputValue,
+  setControlledInputValue
 }: Props<T>): ReturnProps<T> => {
   const ref = useRef<HTMLInputElement>();
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState(defaultValue);
   const [uncontrolledInputValue, setUncontrolledInputValue] = useState('');
 
-  const inputValue = controlledInputStateValue
-    ? controlledInputStateValue.inputValue
+  const inputValue = controlledInputValue
+    ? controlledInputValue
     : uncontrolledInputValue;
-  const setInputValue = controlledInputStateValue
-    ? controlledInputStateValue.setInputValue
+  const setInputValue = setControlledInputValue
+    ? setControlledInputValue
     : setUncontrolledInputValue;
 
   const onOptionClick = useCallback(

--- a/src/molecules/Select/Options/index.tsx
+++ b/src/molecules/Select/Options/index.tsx
@@ -94,7 +94,7 @@ const Options = <T extends {}>({
         );
       }
       case SelectState.ready: {
-        if (options.length === 0) {
+        if (options.length === 0 && userIsSearching) {
           return (
             <MenuItem disabled data-qaid={`${qaId}-empty-msg`}>
               No options...

--- a/src/molecules/Select/index.tsx
+++ b/src/molecules/Select/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useSelect } from '../../hooks';
+import { useSelect, ControlledInputStateValue } from '../../hooks';
 
 import Input from './Input';
 import Options, { OptionsListProps } from './Options';
@@ -25,6 +25,7 @@ export interface SelectProps<T> extends OptionsListProps<T> {
   hasError?: boolean;
   invertColor?: boolean;
   renderLeftIcon?: React.ReactNode;
+  controlledInputStateValue?: ControlledInputStateValue;
 
   // typeahead props
   searchable?: boolean;
@@ -63,6 +64,7 @@ const Select = <T extends {}>({
   initialWidth,
   state = SelectState.ready,
   disableScrollWhenOpen = false,
+  controlledInputStateValue,
   'data-qaid': qaId
 }: SelectProps<T>) => {
   const {
@@ -81,7 +83,8 @@ const Select = <T extends {}>({
     filterBy,
     defaultOptions,
     // @ts-ignore
-    onChange
+    onChange,
+    controlledInputStateValue
   });
 
   return (

--- a/src/molecules/Select/index.tsx
+++ b/src/molecules/Select/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useSelect, ControlledInputStateValue } from '../../hooks';
+import { useSelect } from '../../hooks';
 
 import Input from './Input';
 import Options, { OptionsListProps } from './Options';
@@ -25,7 +25,8 @@ export interface SelectProps<T> extends OptionsListProps<T> {
   hasError?: boolean;
   invertColor?: boolean;
   renderLeftIcon?: React.ReactNode;
-  controlledInputStateValue?: ControlledInputStateValue;
+  inputValue?: string;
+  setInputValue?: React.Dispatch<React.SetStateAction<string>>;
 
   // typeahead props
   searchable?: boolean;
@@ -64,7 +65,8 @@ const Select = <T extends {}>({
   initialWidth,
   state = SelectState.ready,
   disableScrollWhenOpen = false,
-  controlledInputStateValue,
+  inputValue,
+  setInputValue,
   'data-qaid': qaId
 }: SelectProps<T>) => {
   const {
@@ -84,7 +86,8 @@ const Select = <T extends {}>({
     defaultOptions,
     // @ts-ignore
     onChange,
-    controlledInputStateValue
+    controlledInputValue: inputValue,
+    setControlledInputValue: setInputValue
   });
 
   return (


### PR DESCRIPTION
### Description
The Select component handles the text input state internally, however, we need to hoist that up so that the consumer can implement Lazy Loading and Debouncing of the input. This is done via the optional `controlledInputStateValue` prop which is the state and setState from a `useState` call.

### Motivation and Context
Allows consumers to control the input state.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which improves functionality or refactors code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.

